### PR TITLE
A simple stop-gap fix to read-only numpy.diagonal arrays

### DIFF
--- a/lib/stsci/tools/nmpfit.py
+++ b/lib/stsci/tools/nmpfit.py
@@ -1855,7 +1855,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         for j in range(n):
             r[j:n,j] = r[j,j:n]
-        x = numpy.diagonal(r)
+        x = numpy.diagonal(r).copy()
         wa = qtb.copy()
 
         ## Eliminate the diagonal matrix d using a givens rotation


### PR DESCRIPTION
This should address https://github.com/spacetelescope/stsci.tools/issues/4