### PR TITLE
Fix deprecated 'clobber' parameter in astropy.io.fits write functions

### DIFF
--- a/lib/stsci/tools/asnutil.py
+++ b/lib/stsci/tools/asnutil.py
@@ -14,11 +14,9 @@ import astropy
 from astropy.io import fits
 import numpy as N
 import os.path, time
+from distutils.version import LooseVersion
 
-# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
-                       astropy.version.minor >= 3) or
-                      astropy.version.major >= 2)
+ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 __version__ = '0.2(2015-06-23)'
 
@@ -415,7 +413,7 @@ class ASNTable(dict):
         cols = fits.ColDefs([memname,memtype,memprsn,xoffset,yoffset,xdelta,ydelta,rotation,scale])
         hdu = fits.BinTableHDU.from_columns(cols)
         fasn.append(hdu)
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             fasn.writeto(outfile, overwrite=True)
         else:
             fasn.writeto(outfile, clobber=True)

--- a/lib/stsci/tools/asnutil.py
+++ b/lib/stsci/tools/asnutil.py
@@ -16,7 +16,9 @@ import numpy as N
 import os.path, time
 
 # USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
+                       astropy.version.minor >= 3) or
+                      astropy.version.major >= 2)
 
 __version__ = '0.2(2015-06-23)'
 

--- a/lib/stsci/tools/asnutil.py
+++ b/lib/stsci/tools/asnutil.py
@@ -15,6 +15,8 @@ from astropy.io import fits
 import numpy as N
 import os.path, time
 
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
 
 __version__ = '0.2(2015-06-23)'
 
@@ -411,7 +413,10 @@ class ASNTable(dict):
         cols = fits.ColDefs([memname,memtype,memprsn,xoffset,yoffset,xdelta,ydelta,rotation,scale])
         hdu = fits.BinTableHDU.from_columns(cols)
         fasn.append(hdu)
-        fasn.writeto(outfile, clobber=True)
+        if USE_FITS_OVERWRITE:
+            fasn.writeto(outfile, overwrite=True)
+        else:
+            fasn.writeto(outfile, clobber=True)
         fasn.close()
         mem0 = self['order'][0]
         refimg = self['members'][mem0]['refimage']

--- a/lib/stsci/tools/convertlog.py
+++ b/lib/stsci/tools/convertlog.py
@@ -7,21 +7,21 @@
         Usage:
 
                 convertlog.py [OPTIONS] trailer_filename
-        
+
         :Options:
 
         -h         print the help (this text)
 
         -v         print version of task
-        
-        -w     
+
+        -w
         --width    Width (in chars) for trailer file table column
-        
+
         -o
         --output   Name of output FITS trailer file
                    If none is specified, it will convert input file
                    from "rootname.tra" to "rootname_trl.fits"
-        
+
         :Example:
 
         If used in Pythons script, a user can, e. g.::
@@ -53,35 +53,35 @@ import textwrap
 def convert(input, width=132, output=None, keep=False):
 
     """Input ASCII trailer file "input" will be read.
-    
+
     The contents will then be written out to a FITS file in the same format
     as used by 'stwfits' from IRAF.
-    
+
     Parameters
     ===========
     input : str
         Filename of input ASCII trailer file
-        
+
     width : int
         Number of characters wide to use for defining output FITS column
         [Default: 132]
-    
+
     output : str
         Filename to use for writing out converted FITS trailer file
         If None, input filename will be converted from *.tra -> *_trl.fits
         [Default: None]
-        
+
     keep : bool
         Specifies whether or not to keep any previously written FITS files
         [Default: False]
-        
+
     """
     # open input trailer file
     trl = open(input)
-    
+
     # process all lines
     lines = np.array([i for text in trl.readlines() for i in textwrap.wrap(text,width=width)])
-    
+
     # close ASCII trailer file now that we have processed all the lines
     trl.close()
 
@@ -101,7 +101,7 @@ def convert(input, width=132, output=None, keep=False):
             raise IOError
         else:
             os.remove(full_name)
-    
+
     # Build FITS table and write it out
     line_fmt = "{}A".format(width)
     tbhdu = fits.BinTableHDU.from_columns([fits.Column(name='TEXT_FILE',format=line_fmt,array=lines)])
@@ -110,13 +110,13 @@ def convert(input, width=132, output=None, keep=False):
     print("Created output FITS filename for trailer:{}    {}".format(os.linesep,full_name))
 
     os.remove(input)
-    
+
 def usage():
     print(__doc__)
-    
+
 def main():
     import getopt
-    
+
     try:
         optlist, args = getopt.getopt(sys.argv[1:], 'hvkw:o:')
     except getopt.error as e:
@@ -127,9 +127,8 @@ def main():
 
     output = None
     width = 132
-    clobber=False
     keep = False
-    
+
     for o, a in optlist:
         if o in ("-h", "--help"):
             usage()
@@ -151,7 +150,7 @@ def main():
     except:
         print("ERROR: Convertlog failed to convert: {}".format(trl_file))
         sys.exit(2)
-    
+
 #-------------------------------------------------------------------------------
 # special initialization when this is the main program
 

--- a/lib/stsci/tools/convertwaiveredfits.py
+++ b/lib/stsci/tools/convertwaiveredfits.py
@@ -152,7 +152,12 @@ else:
 #
 import os
 import sys
+import astropy
 from astropy.io import fits
+
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+
 #
 # -----------------------------------------------------------------------------
 # Function definitions
@@ -516,7 +521,11 @@ def toMultiExtensionFits(waiveredObject,
             head,tail = os.path.split(multiExtensionFileName)
             mhdul[0].header.set('FILENAME', value=tail, after='NEXTEND')
 
-        mhdul.writeto(multiExtensionFileName,clobber=True)
+        if USE_FITS_OVERWRITE:
+            mhdul.writeto(multiExtensionFileName, overwrite=True)
+        else:
+            mhdul.writeto(multiExtensionFileName, clobber=True)
+
         verboseString = verboseString[:-1] + " and written to " + \
                         multiExtensionFileName + "."
 

--- a/lib/stsci/tools/convertwaiveredfits.py
+++ b/lib/stsci/tools/convertwaiveredfits.py
@@ -154,9 +154,9 @@ import os
 import sys
 import astropy
 from astropy.io import fits
+from distutils.version import LooseVersion
 
-# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 #
 # -----------------------------------------------------------------------------
@@ -521,7 +521,7 @@ def toMultiExtensionFits(waiveredObject,
             head,tail = os.path.split(multiExtensionFileName)
             mhdul[0].header.set('FILENAME', value=tail, after='NEXTEND')
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             mhdul.writeto(multiExtensionFileName, overwrite=True)
         else:
             mhdul.writeto(multiExtensionFileName, clobber=True)

--- a/lib/stsci/tools/fileutil.py
+++ b/lib/stsci/tools/fileutil.py
@@ -91,6 +91,7 @@ import sys
 
 import time as _time
 import numpy as np
+from distutils.version import LooseVersion
 
 PY3K = sys.version_info[0] > 2
 if PY3K:
@@ -98,10 +99,7 @@ if PY3K:
 else:
     string_types = basestring
 
-# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
-                       astropy.version.minor >= 3) or
-                      astropy.version.major >= 2)
+ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 # Environment variable handling - based on iraffunctions.py
 # define INDEF, yes, no, EOF, Verbose, userIrafHome
@@ -748,13 +746,13 @@ def openImage(filename, mode='readonly', memmap=0, writefits=True,
                 fexists = os.path.exists(fitsname)
                 if (fexists and clobber) or not fexists:
                     print('Writing out WAIVERED as MEF to ', fitsname)
-                    if USE_FITS_OVERWRITE:
+                    if ASTROPY_VER_GE13:
                         fimg.writeto(fitsname, overwrite=clobber)
                     else:
                         fimg.writeto(fitsname, clobber=clobber)
                     if dqexists:
                         print('Writing out WAIVERED as MEF to ', dqfitsname)
-                        if USE_FITS_OVERWRITE:
+                        if ASTROPY_VER_GE13:
                             dqfile.writeto(dqfitsname, overwrite=clobber)
                         else:
                             dqfile.writeto(dqfitsname, clobber=clobber)
@@ -801,13 +799,13 @@ def openImage(filename, mode='readonly', memmap=0, writefits=True,
             fexists = os.path.exists(fitsname)
             if (fexists and clobber) or not fexists:
                     print('Writing out GEIS as MEF to ', fitsname)
-                    if USE_FITS_OVERWRITE:
+                    if ASTROPY_VER_GE13:
                         fimg.writeto(fitsname, overwrite=clobber)
                     else:
                         fimg.writeto(fitsname, clobber=clobber)
                     if dqexists:
                         print('Writing out GEIS as MEF to ', dqfitsname)
-                        if USE_FITS_OVERWRITE:
+                        if ASTROPY_VER_GE13:
                             dqfile.writeto(dqfitsname, overwrite=clobber)
                         else:
                             dqfile.writeto(dqfitsname, clobber=clobber)

--- a/lib/stsci/tools/fileutil.py
+++ b/lib/stsci/tools/fileutil.py
@@ -77,6 +77,7 @@ from __future__ import division, print_function # confidence high
 from . import numerixenv
 numerixenv.check()
 
+import astropy
 from . import stpyfits as fits
 from . import readgeis
 from . import convertwaiveredfits
@@ -96,6 +97,9 @@ if PY3K:
     string_types = str
 else:
     string_types = basestring
+
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
 
 # Environment variable handling - based on iraffunctions.py
 # define INDEF, yes, no, EOF, Verbose, userIrafHome
@@ -507,7 +511,7 @@ def buildRootname(filename, ext=None):
 
             if rootname is not None:
                 break
-    
+
     # If we still haven't found the file, see if we have the
     # info to build one...
     if rootname is None and ext is not None:
@@ -742,10 +746,16 @@ def openImage(filename, mode='readonly', memmap=0, writefits=True,
                 fexists = os.path.exists(fitsname)
                 if (fexists and clobber) or not fexists:
                     print('Writing out WAIVERED as MEF to ', fitsname)
-                    fimg.writeto(fitsname, clobber=clobber)
+                    if USE_FITS_OVERWRITE:
+                        fimg.writeto(fitsname, overwrite=clobber)
+                    else:
+                        fimg.writeto(fitsname, clobber=clobber)
                     if dqexists:
                         print('Writing out WAIVERED as MEF to ', dqfitsname)
-                        dqfile.writeto(dqfitsname, clobber=clobber)
+                        if USE_FITS_OVERWRITE:
+                            dqfile.writeto(dqfitsname, overwrite=clobber)
+                        else:
+                            dqfile.writeto(dqfitsname, clobber=clobber)
                 # Now close input GEIS image, and open writable
                 # handle to output FITS image instead...
                 fimg.close()
@@ -789,10 +799,16 @@ def openImage(filename, mode='readonly', memmap=0, writefits=True,
             fexists = os.path.exists(fitsname)
             if (fexists and clobber) or not fexists:
                     print('Writing out GEIS as MEF to ', fitsname)
-                    fimg.writeto(fitsname, clobber=clobber)
+                    if USE_FITS_OVERWRITE:
+                        fimg.writeto(fitsname, overwrite=clobber)
+                    else:
+                        fimg.writeto(fitsname, clobber=clobber)
                     if dqexists:
                         print('Writing out GEIS as MEF to ', dqfitsname)
-                        dqfile.writeto(dqfitsname, clobber=clobber)
+                        if USE_FITS_OVERWRITE:
+                            dqfile.writeto(dqfitsname, overwrite=clobber)
+                        else:
+                            dqfile.writeto(dqfitsname, clobber=clobber)
             # Now close input GEIS image, and open writable
             # handle to output FITS image instead...
             fimg.close()

--- a/lib/stsci/tools/fileutil.py
+++ b/lib/stsci/tools/fileutil.py
@@ -99,7 +99,9 @@ else:
     string_types = basestring
 
 # USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
+                       astropy.version.minor >= 3) or
+                      astropy.version.major >= 2)
 
 # Environment variable handling - based on iraffunctions.py
 # define INDEF, yes, no, EOF, Verbose, userIrafHome

--- a/lib/stsci/tools/tests/testStpyfits.py
+++ b/lib/stsci/tools/tests/testStpyfits.py
@@ -9,10 +9,13 @@ from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 import stsci.tools.stpyfits as stpyfits
 #import pyfits
+import astropy
 from astropy.io import fits
 #from pyfits.tests import PyfitsTestCase
 from astropy.io.fits.tests import FitsTestCase
 
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
 
 class TestStpyfitsFunctions(FitsTestCase):
     def setup(self):
@@ -144,10 +147,19 @@ class TestStpyfitsFunctions(FitsTestCase):
         header = hdul[0].header.copy()
         header['NAXIS'] = 0
 
-        stpyfits.writeto(self.temp('new.fits'), hdul[0].data, header,
-                         clobber=True)
-        fits.writeto(self.temp('new1.fits'), hdul1[0].data,hdul1[0].header,
-                     clobber=True)
+        if USE_FITS_OVERWRITE:
+            stpyfits.writeto(self.temp('new.fits'), hdul[0].data, header,
+                             overwrite=True)
+        else:
+            stpyfits.writeto(self.temp('new.fits'), hdul[0].data, header,
+                             clobber=True)
+
+        if USE_FITS_OVERWRITE:
+            fits.writeto(self.temp('new1.fits'), hdul1[0].data,
+                         hdul1[0].header, overwrite=True)
+        else:
+            fits.writeto(self.temp('new1.fits'), hdul1[0].data,
+                         hdul1[0].header, clobber=True)
 
         hdul.close()
         hdul1.close()
@@ -171,10 +183,19 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdul = stpyfits.open(self.data('cdva2.fits'))
         hdul1 = fits.open(self.data('cdva2.fits'))
 
-        stpyfits.writeto(self.temp('new.fits'), hdul[0].data, hdul[0].header,
-                         clobber=True)
-        fits.writeto(self.temp('new1.fits'), hdul1[0].data, hdul1[0].header,
-                       clobber=True)
+        if USE_FITS_OVERWRITE:
+            stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
+                             hdul[0].header, overwrite=True)
+        else:
+            stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
+                             hdul[0].header, clobber=True)
+
+        if USE_FITS_OVERWRITE:
+            fits.writeto(self.temp('new1.fits'), hdul1[0].data,
+                         hdul1[0].header, overwrite=True)
+        else:
+            fits.writeto(self.temp('new1.fits'), hdul1[0].data,
+                         hdul1[0].header, clobber=True)
 
         hdu = stpyfits.ImageHDU()
         hdu1 = fits.ImageHDU()
@@ -243,8 +264,14 @@ class TestStpyfitsFunctions(FitsTestCase):
 
         header = hdul[0].header.copy()
         header['NAXIS'] = 0
-        stpyfits.writeto(self.temp('new.fits'), hdul[0].data, header,
-                         clobber=True)
+
+        if USE_FITS_OVERWRITE:
+            stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
+                             header, overwrite=True)
+        else:
+            stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
+                             header, clobber=True)
+
 
         hdu = stpyfits.ImageHDU()
         hdu1 = fits.ImageHDU()
@@ -324,8 +351,14 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu = stpyfits.PrimaryHDU(n)
         hdu.header.set('PIXVALUE', 1.0, 'Constant pixel value', after='EXTEND')
         hdu.header.set('NAXIS', 0)
-        stpyfits.writeto(self.temp('new.fits'), hdu.data, hdu.header,
-                         clobber=True)
+
+        if USE_FITS_OVERWRITE:
+            stpyfits.writeto(self.temp('new.fits'), hdu.data, hdu.header,
+                             overwrite=True)
+        else:
+            stpyfits.writeto(self.temp('new.fits'), hdu.data, hdu.header,
+                             clobber=True)
+
         hdul = stpyfits.open(self.temp('new.fits'))
         hdul1 = fits.open(self.temp('new.fits'))
 
@@ -371,7 +404,10 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu1.header.set('NAXIS2', 10, 'length of constant array axis 2',
                         after='NAXIS1')
         hdul = stpyfits.HDUList([hdu,hdu1])
-        hdul.writeto(self.temp('new.fits'), clobber=True)
+        if USE_FITS_OVERWRITE:
+            hdul.writeto(self.temp('new.fits'), overwrite=True)
+        else:
+            hdul.writeto(self.temp('new.fits'), clobber=True)
 
         assert_equal(stpyfits.info(self.temp('new.fits'), output=False),
             [(0, 'PRIMARY', 'PrimaryHDU', 7, (10, 10), 'int32', ''),
@@ -437,7 +473,10 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu = stpyfits.PrimaryHDU(n)
         hdu.header.set('PIXVALUE', 1., 'constant pixel value', after='EXTEND')
 
-        hdu.writeto(self.temp('new.fits'), clobber=True)
+        if USE_FITS_OVERWRITE:
+            hdu.writeto(self.temp('new.fits'), overwrite=True)
+        else:
+            hdu.writeto(self.temp('new.fits'), clobber=True)
 
         hdul = stpyfits.open(self.temp('new.fits'))
         hdul1 = fits.open(self.temp('new.fits'))
@@ -486,7 +525,10 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu1.header.set('NAXIS2', 10, 'length of constant array axis 2',
                         after='NAXIS1')
         hdul = stpyfits.HDUList([hdu, hdu1])
-        hdul.writeto(self.temp('new.fits'), clobber=True)
+        if USE_FITS_OVERWRITE:
+            hdul.writeto(self.temp('new.fits'), overwrite=True)
+        else:
+            hdul.writeto(self.temp('new.fits'), clobber=True)
 
         hdul = stpyfits.open(self.temp('new.fits'), 'update')
         d = np.arange(10, dtype=np.int32)
@@ -589,7 +631,10 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu = stpyfits.PrimaryHDU(n)
         hdu.header.set('PIXVALUE', 1., 'constant pixel value', after='EXTEND')
 
-        hdu.writeto(self.temp('new.fits'), clobber=True)
+        if USE_FITS_OVERWRITE:
+            hdu.writeto(self.temp('new.fits'), overwrite=True)
+        else:
+            hdu.writeto(self.temp('new.fits'), clobber=True)
 
         hdul = stpyfits.open(self.temp('new.fits'))
         hdul1 = fits.open(self.temp('new.fits'))

--- a/lib/stsci/tools/tests/testStpyfits.py
+++ b/lib/stsci/tools/tests/testStpyfits.py
@@ -15,7 +15,9 @@ from astropy.io import fits
 from astropy.io.fits.tests import FitsTestCase
 
 # USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
+                       astropy.version.minor >= 3) or
+                      astropy.version.major >= 2)
 
 class TestStpyfitsFunctions(FitsTestCase):
     def setup(self):

--- a/lib/stsci/tools/tests/testStpyfits.py
+++ b/lib/stsci/tools/tests/testStpyfits.py
@@ -5,6 +5,8 @@ import os
 import tempfile
 
 import numpy as np
+from distutils.version import LooseVersion
+
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 import stsci.tools.stpyfits as stpyfits
@@ -14,10 +16,7 @@ from astropy.io import fits
 #from pyfits.tests import PyfitsTestCase
 from astropy.io.fits.tests import FitsTestCase
 
-# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
-                       astropy.version.minor >= 3) or
-                      astropy.version.major >= 2)
+ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 class TestStpyfitsFunctions(FitsTestCase):
     def setup(self):
@@ -149,14 +148,14 @@ class TestStpyfitsFunctions(FitsTestCase):
         header = hdul[0].header.copy()
         header['NAXIS'] = 0
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             stpyfits.writeto(self.temp('new.fits'), hdul[0].data, header,
                              overwrite=True)
         else:
             stpyfits.writeto(self.temp('new.fits'), hdul[0].data, header,
                              clobber=True)
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             fits.writeto(self.temp('new1.fits'), hdul1[0].data,
                          hdul1[0].header, overwrite=True)
         else:
@@ -185,14 +184,14 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdul = stpyfits.open(self.data('cdva2.fits'))
         hdul1 = fits.open(self.data('cdva2.fits'))
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
                              hdul[0].header, overwrite=True)
         else:
             stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
                              hdul[0].header, clobber=True)
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             fits.writeto(self.temp('new1.fits'), hdul1[0].data,
                          hdul1[0].header, overwrite=True)
         else:
@@ -267,7 +266,7 @@ class TestStpyfitsFunctions(FitsTestCase):
         header = hdul[0].header.copy()
         header['NAXIS'] = 0
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             stpyfits.writeto(self.temp('new.fits'), hdul[0].data,
                              header, overwrite=True)
         else:
@@ -354,7 +353,7 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu.header.set('PIXVALUE', 1.0, 'Constant pixel value', after='EXTEND')
         hdu.header.set('NAXIS', 0)
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             stpyfits.writeto(self.temp('new.fits'), hdu.data, hdu.header,
                              overwrite=True)
         else:
@@ -406,7 +405,7 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu1.header.set('NAXIS2', 10, 'length of constant array axis 2',
                         after='NAXIS1')
         hdul = stpyfits.HDUList([hdu,hdu1])
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             hdul.writeto(self.temp('new.fits'), overwrite=True)
         else:
             hdul.writeto(self.temp('new.fits'), clobber=True)
@@ -475,7 +474,7 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu = stpyfits.PrimaryHDU(n)
         hdu.header.set('PIXVALUE', 1., 'constant pixel value', after='EXTEND')
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             hdu.writeto(self.temp('new.fits'), overwrite=True)
         else:
             hdu.writeto(self.temp('new.fits'), clobber=True)
@@ -527,7 +526,7 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu1.header.set('NAXIS2', 10, 'length of constant array axis 2',
                         after='NAXIS1')
         hdul = stpyfits.HDUList([hdu, hdu1])
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             hdul.writeto(self.temp('new.fits'), overwrite=True)
         else:
             hdul.writeto(self.temp('new.fits'), clobber=True)
@@ -633,7 +632,7 @@ class TestStpyfitsFunctions(FitsTestCase):
         hdu = stpyfits.PrimaryHDU(n)
         hdu.header.set('PIXVALUE', 1., 'constant pixel value', after='EXTEND')
 
-        if USE_FITS_OVERWRITE:
+        if ASTROPY_VER_GE13:
             hdu.writeto(self.temp('new.fits'), overwrite=True)
         else:
             hdu.writeto(self.temp('new.fits'), clobber=True)


### PR DESCRIPTION
The ``clobber`` parameter in ``astropy.io.fits`` write functions has been deprecated and it has been replaced with ``overwrite``: see https://github.com/astropy/astropy/pull/5171.

This has caused our code (see, e.g., ``drizzlepac`` - https://github.com/spacetelescope/drizzlepac/issues/15) to issue numerous deprecation warnings.

This PR updates the code in ``stsci.tools`` so that it uses ``overwrite`` for versions of astropy  >= 1.3 and ``clobber`` for verions < 1.3 (for backward compatibility).