### PR TITLE
Fix a bug in handling IVM lists for STIS images

### DIFF
--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -3,6 +3,7 @@ from __future__ import division, print_function # confidence high
 from stsci.tools import parseinput, fileutil
 from astropy.io import fits
 import os
+from stwcs import updatewcs
 
 def checkFiles(filelist,ivmlist = None):
     """
@@ -70,7 +71,7 @@ def checkFITSFormat(filelist, ivmlist=None):
     return newfilelist, ivmlist
 
 
-def checkStisFiles(filelist, ivmlist=None):
+def checkStisFiles(filelist, ivmlist=None, asn_updatewcs=False):
     newflist = []
     newilist = []
     removed_files = []
@@ -94,13 +95,17 @@ def checkStisFiles(filelist, ivmlist=None):
         sci_count = stisObsCount(t[0])
         if sci_count >1:
             newfilenames = splitStis(t[0], sci_count)
+            if asn_updatewcs:
+                for f in newfilenames:
+                    updatewcs.updatewcs(f)
             assoc_files.extend(newfilenames)
             removed_files.append(t[0])
             if (isinstance(t[1], tuple) and t[1][0] is not None) or \
                (not isinstance(t[1], tuple) and t[1] is not None):
                 print('Does not handle STIS IVM files and STIS association files\n')
             else:
-                assoc_ilist.extend([None]*len(assoc_files))
+                asn_ivmlist = list(zip(sci_count * [None], newfilenames))
+                assoc_ilist.extend(asn_ivmlist)
         elif sci_count == 1:
             newflist.append(t[0])
             newilist.append(t[1])

--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -71,7 +71,7 @@ def checkFITSFormat(filelist, ivmlist=None):
     return newfilelist, ivmlist
 
 
-def checkStisFiles(filelist, ivmlist=None, asn_updatewcs=False):
+def checkStisFiles(filelist, ivmlist=None):
     newflist = []
     newilist = []
     removed_files = []
@@ -95,9 +95,9 @@ def checkStisFiles(filelist, ivmlist=None, asn_updatewcs=False):
         sci_count = stisObsCount(t[0])
         if sci_count >1:
             newfilenames = splitStis(t[0], sci_count)
-            if asn_updatewcs:
-                for f in newfilenames:
-                    updatewcs.updatewcs(f)
+            import inspect
+            curframe = inspect.currentframe()
+            calframe = inspect.getouterframes(curframe, 2)
             assoc_files.extend(newfilenames)
             removed_files.append(t[0])
             if (isinstance(t[1], tuple) and t[1][0] is not None) or \

--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -3,7 +3,6 @@ from __future__ import division, print_function # confidence high
 from stsci.tools import parseinput, fileutil
 from astropy.io import fits
 import os
-from stwcs import updatewcs
 
 def checkFiles(filelist,ivmlist = None):
     """
@@ -95,9 +94,6 @@ def checkStisFiles(filelist, ivmlist=None):
         sci_count = stisObsCount(t[0])
         if sci_count >1:
             newfilenames = splitStis(t[0], sci_count)
-            import inspect
-            curframe = inspect.currentframe()
-            calframe = inspect.getouterframes(curframe, 2)
             assoc_files.extend(newfilenames)
             removed_files.append(t[0])
             if (isinstance(t[1], tuple) and t[1][0] is not None) or \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.tools
-version = 3.4.6
+version = 3.4.7
 author = STScI
 author-email = help@stsci.edu
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python


### PR DESCRIPTION
When ``astrodrizzle``'s input image is a STIS ASN image ("multi-imset STIS ``_flt`` files"), IVM file list created by ``checkStisFiles()`` does not have correct format which leads to crashes in ``AstroDrizzle``.

This PR fixes IVM list bug for STIS.

However, since https://trac.stsci.edu/ssb/stsci_python/ticket/1217, users will have to unpack multi-imset STIS ``_flt`` files themselves because ``AstroDrizzle`` no longer runs ``updatewcs`` on input images.

CC: @stsci-hack 