### PR TITLE
Don't overwrite ( or assign string values to the) built-in 'str' type

### DIFF
--- a/lib/stsci/tools/convertgeis.py
+++ b/lib/stsci/tools/convertgeis.py
@@ -390,11 +390,16 @@ def parse_path(f1, f2):
     else:
         list2 = [s.strip() for s in f2.split(",")]
 
-    if (list1 == [] or list2 == []):
-        str = ""
-        if (list1 == []): str += "Input files `%s` not usable/available. " % f1
-        if (list2 == []): str += "Input files `%s` not usable/available. " % f2
-        raise IOError(str)
+    if list1 == [] or list2 == []:
+        err_msg = ""
+        if list1 == []:
+            err_msg += "Input files `{:s}` not usable/available. ".format(f1)
+
+        if list2 == []:
+            err_msg += "Input files `{:s}` not usable/available. ".format(f2)
+
+        raise IOError(err_msg)
+
     else:
         return list1, list2
 

--- a/lib/stsci/tools/filedlg.py
+++ b/lib/stsci/tools/filedlg.py
@@ -323,8 +323,8 @@ class LoadFileDialog(FileDialog):
     def OkPressed(self):
         fileName = self.GetFileName()
         if os.path.exists(fileName) == 0:
-            str = 'File ' + fileName + ' not found.'
-            errorDlg = alert.ErrorDialog(self.top, str)
+            msg = 'File ' + fileName + ' not found.'
+            errorDlg = alert.ErrorDialog(self.top, msg)
             errorDlg.Show()
             errorDlg.DialogCleanup()
             return
@@ -348,8 +348,8 @@ class SaveFileDialog(FileDialog):
     def OkPressed(self):
         fileName = self.GetFileName()
         if os.path.exists(fileName) == 1:
-            str = 'File ' + fileName + ' exists.\nDo you wish to overwrite it?'
-            warningDlg = alert.WarningDialog(self.top, str)
+            msg = 'File ' + fileName + ' exists.\nDo you wish to overwrite it?'
+            warningDlg = alert.WarningDialog(self.top, msg)
             if warningDlg.Show() == 0:
                 warningDlg.DialogCleanup()
                 return
@@ -412,8 +412,8 @@ class PersistLoadFileDialog(PersistFileDialog):
     def OkPressed(self):
         fileName = self.GetFileName()
         if os.path.exists(fileName) == 0:
-            str = 'File ' + fileName + ' not found.'
-            errorDlg = alert.ErrorDialog(self.top, str)
+            msg = 'File ' + fileName + ' not found.'
+            errorDlg = alert.ErrorDialog(self.top, msg)
             errorDlg.Show()
             errorDlg.DialogCleanup()
             return
@@ -437,8 +437,8 @@ class PersistSaveFileDialog(PersistFileDialog):
     def OkPressed(self):
         fileName = self.GetFileName()
         if os.path.exists(fileName) == 1:
-            str = 'File ' + fileName + ' exists.\nDo you wish to overwrite it?'
-            warningDlg = alert.WarningDialog(self.top, str)
+            msg = 'File ' + fileName + ' exists.\nDo you wish to overwrite it?'
+            warningDlg = alert.WarningDialog(self.top, msg)
             if warningDlg.Show() == 0:
                 warningDlg.DialogCleanup()
                 return

--- a/lib/stsci/tools/readgeis.py
+++ b/lib/stsci/tools/readgeis.py
@@ -349,11 +349,16 @@ def parse_path(f1, f2):
     else:
         list2 = [s.strip() for s in f2.split(",")]
 
-    if (list1 == [] or list2 == []):
-        str = ""
-        if (list1 == []): str += "Input files `%s` not usable/available. " % f1
-        if (list2 == []): str += "Input files `%s` not usable/available. " % f2
-        raise IOError(str)
+    if list1 == [] or list2 == []:
+        err_msg = ""
+        if list1 == []:
+            err_msg += "Input files `{:s}` not usable/available. ".format(f1)
+
+        if list2 == []:
+            err_msg += "Input files `{:s}` not usable/available. ".format(f2)
+
+        raise IOError(err_msg)
+
     else:
         return list1, list2
 

--- a/lib/stsci/tools/swapgeis.py
+++ b/lib/stsci/tools/swapgeis.py
@@ -544,13 +544,19 @@ def parse_path(f1, f2):
     else:
         list2 = [s.strip() for s in f2.split(",")]
 
-    if (list1 == [] or list2 == []):
-        str = ""
-        if (list1 == []): str += "Input files `%s` not usable/available. " % f1
-        if (list2 == []): str += "Input files `%s` not usable/available. " % f2
-        raise IOError(str)
+    if list1 == [] or list2 == []:
+        err_msg = ""
+        if list1 == []:
+            err_msg += "Input files `{:s}` not usable/available. ".format(f1)
+
+        if list2 == []:
+            err_msg += "Input files `{:s}` not usable/available. ".format(f2)
+
+        raise IOError(err_msg)
+
     else:
         return list1, list2
+
 
 #-------------------------------------------------------------------------------
 # special initialization when this is the main program


### PR DESCRIPTION
A long time ago some fellows used to overwrite Python's built-in ``str`` type with string values. This was causing problems in ``drizzlepac`` (see, e.g., https://github.com/spacetelescope/drizzlepac/pull/55). This PR renames ``str`` **variable** to something else to avoid possible conflicts.