### PR TITLE
update version to 3.4.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.tools
-version = 3.4.7
+version = 3.4.9
 author = STScI
 author-email = help@stsci.edu
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python


### PR DESCRIPTION
Unfortunately, I tagged previous changes with 3.4.8 without bumping version in the ``setup.cfg``. Here I bump the version to 3.4.9 followed by a tag update to the same version.