### PR TITLE
Updated stpyfits to replace deprecated function NumCode

### DIFF
--- a/lib/stsci/tools/stpyfits.py
+++ b/lib/stsci/tools/stpyfits.py
@@ -155,7 +155,7 @@ class _ConstantValueImageBaseHDU(fits.hdu.image._ImageBaseHDU):
             if sum(dims) == 0:
                 return None
 
-            code = self.NumCode[bitpix]
+            code = BITPIX2DTYPE[bitpix]
             pixval = self._header['PIXVALUE']
             if code in ['uint8', 'int16', 'int32', 'int64']:
                 if PY3K:


### PR DESCRIPTION
This simple update to stpyfits addresses Issue #35 by replacing the call to io.fits.NumCode with the call to the BITPIX2DTYPE dict instead. 

Manual testing indicates this resolves the problem identified during pipeline testing. However, this needs to be reviewed by someone familiar with io.fits ( @jhunkeler ?) or someone who uses it for pipeline support ( @mcara ) before being merged into master.