### PR TITLE
Bump version 3.4.9 -> 3.4.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.tools
-version = 3.4.9
+version = 3.4.10
 author = STScI
 author-email = help@stsci.edu
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python


### PR DESCRIPTION
Refers to https://github.com/spacetelescope/stsci.tools/pull/36