### PR TITLE
stpyfits: disable lazy loading

### DIFF
--- a/lib/stsci/tools/stpyfits.py
+++ b/lib/stsci/tools/stpyfits.py
@@ -48,6 +48,10 @@ def with_stpyfits(func):
         was_enabled = STPYFITS_ENABLED
         enable_stpyfits()
         try:
+            # BUG: Forcefully disable lazy loading.
+            # Lazy loading breaks ability to initialize ConstantValueHDUs
+            # TODO: Investigate the cause upstream (astropy.io.fits)
+            kwargs['lazy_load_hdus'] = False
             retval = func(*args, **kwargs)
         finally:
             # Only disable stpyfits if it wasn't already enabled


### PR DESCRIPTION
cc @stsci-hack

This PR disables lazy loading. With lazy loading enabled `with_stpyfits` fails to populate `ConstantValueHDU`s. The root cause still needs further investigation.

# Bug

With lazy loading enabled:

```python
>>> from stsci.tools import stpyfits as sfits
>>> fimg = sfits.open('j9bc59wfq_raw.fits',mode='update')
>>> fimg.info()
Filename: j9bc59wfq_raw.fits
No.    Name         Type      Cards   Dimensions   Format
 0  PRIMARY     PrimaryHDU     221   ()
 1  SCI         ImageHDU       146   (200, 200)   int16
 2  ERR         ImageHDU        58   ()
 3  DQ          ImageHDU        50   ()
 4  WCSCORR     BinTableHDU     59   7R x 24C   [40A, I, A, 24A, 24A, 24A, 24A, D, D, D, D, D, D, D, D, 24A, 24A, D, D, D, D, J, 40A, 128A]
>>> fimage[2].data
None
```

# Expected behavior

With lazy loading disabled:
```python
>>> from stsci.tools import stpyfits as sfits
>>> fimg = sfits.open('j9bc59wfq_raw.fits',mode='update')
>>> fimg.info()
No.    Name         Type      Cards   Dimensions   Format
  0  PRIMARY     PrimaryHDU     221   ()      
  1  SCI         ImageHDU       146   (200, 200)   int16   
  2  ERR         ImageHDU        58   (200, 200)   int16   
  3  DQ          ImageHDU        50   (200, 200)   int16   
  4  WCSCORR     BinTableHDU     59   7R x 24C   [40A, I, A, 24A, 24A, 24A, 24A, D, D, D, D, D, D, D, D, 24A, 24A, D, D, D, D, J, 40A, 128A]   
>>> fimg[2].data
[[0 0 0 ..., 0 0 0]
 [0 0 0 ..., 0 0 0]
 [0 0 0 ..., 0 0 0]
 ..., 
 [0 0 0 ..., 0 0 0]
 [0 0 0 ..., 0 0 0]
 [0 0 0 ..., 0 0 0]]

```