### PR TITLE
Fix incorrect deprecation warning for bitmask.bitmask2mask

### DIFF
--- a/lib/stsci/tools/bitmask.py
+++ b/lib/stsci/tools/bitmask.py
@@ -503,7 +503,7 @@ def interpret_bits_value(val):
 
 
 @deprecated(since='3.4.6', message='', name='bitmask2mask',
-            alternative='flags_to_boolean_mask')
+            alternative='bitfield_to_boolean_mask')
 def bitmask2mask(bitmask, ignore_bits, good_mask_value=1, dtype=np.bool_):
     """
     bitmask2mask(bitmask, ignore_bits, good_mask_value=1, dtype=numpy.bool\_)


### PR DESCRIPTION
@SaraOgaz reported that a deprecation warning for ``bitmask.bitmask2mask()`` incorrectly stated that users should use ``bitmask.flags_to_boolean_mask()`` - a non-existent function. The correct warning should point towards ``bitmask.bitfield_to_boolean_mask()``. This PR corrects the deprecation warning for ``bitmask.bitmask2mask()``.