### PR TITLE
Skip empty lines in irafglob

### DIFF
--- a/lib/stsci/tools/irafglob.py
+++ b/lib/stsci/tools/irafglob.py
@@ -29,26 +29,29 @@ def irafglob(inlist, atfile=None):
         #  python list
         flist = []
         for f in inlist:
-            flist += irafglob(f)
+            fs = f.strip()
+            if fs == '':
+                continue
+            flist += irafglob(fs)
     elif ',' in inlist:
         #  comma-separated string list
         flist = []
         for f in inlist.split(','):
-            f = f.strip()
-            if f == '':
+            fs = f.strip()
+            if fs == '':
                 continue
-            flist += irafglob(f)
+            flist += irafglob(fs)
     elif inlist[0] == '@':
         #  file list
         flist = []
         for f in open(inlist[1:], 'r').readlines():
-            f = f.strip()
-            if f == '':
+            fs = f.strip()
+            if fs == '':
                 continue
             # hook for application specific atfiles.
             if atfile:
-                f = atfile(f)
-            flist += irafglob(f)
+                fs = atfile(fs)
+            flist += irafglob(fs)
     else:
         #  shell globbing
         if osfn:

--- a/lib/stsci/tools/irafglob.py
+++ b/lib/stsci/tools/irafglob.py
@@ -35,12 +35,16 @@ def irafglob(inlist, atfile=None):
         flist = []
         for f in inlist.split(','):
             f = f.strip()
+            if f == '':
+                continue
             flist += irafglob(f)
     elif inlist[0] == '@':
         #  file list
         flist = []
         for f in open(inlist[1:], 'r').readlines():
-            f = f.rstrip()
+            f = f.strip()
+            if f == '':
+                continue
             # hook for application specific atfiles.
             if atfile:
                 f = atfile(f)


### PR DESCRIPTION
While working on https://github.com/spacetelescope/drizzlepac/pull/90 I have noticed that `tweakreg` was not saving log files. After a lengthy digging into the code, the root-cause of this was due to `atfile_sci` being called on empty file names (`''`). This was caused by an input `@-file` containing two empty lines at the end. This can be solved at the top level (`irafglob`) by filtering out empty string file names.

This PR adds code to `irafglob` that checks if file names are empty strings (after stripping white spaces) and skips these names.