### PR TITLE
Remove build-time dependencies from run-time

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,6 @@ classifier =
 	Topic :: Software Development :: Libraries :: Python Modules
 requires-python = >=2.6
 requires-dist = 
-	d2to1
-	setuptools
-	stsci.distutils
 	astropy (>=0.3.1)
 	numpy (>=1.5.1)
 


### PR DESCRIPTION
This change prevents the following error:
```python
pkg_resources.DistributionNotFound: The 'stsci.distutils' distribution was not found and is required by stsci.tools
```

The `d2to1` and `stsci.distutils` dependencies are handled by `setup_requires` in `setup.py`, and should not be installed directly into the environment. This package does not use either, post-install. `setuptools` is not required either, because the installation is handled indirectly by `stsci.distutils`...

**stsci.distutils/setup.cfg:**
```ini
requires-dist = 
    setuptools
    d2to1 (>=0.2.5)
```