### PR TITLE
Fix GEIS modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 build/
 dist/
+version.py
 *.egg-info/
 */*/version.py
 *.so

--- a/lib/stsci/tools/convertgeis.py
+++ b/lib/stsci/tools/convertgeis.py
@@ -219,7 +219,7 @@ def convert(input):
 
     _shape = _naxis[1:]
     _shape.reverse()
-    _code = fits.hdu.ImageHDU.NumCode[_bitpix]
+    _code = fits.BITPIX2DTYPE[_bitpix]
     _bscale = phdr.get('BSCALE', 1)
     _bzero = phdr.get('BZERO', 0)
 

--- a/lib/stsci/tools/readgeis.py
+++ b/lib/stsci/tools/readgeis.py
@@ -202,7 +202,7 @@ def readgeis(input):
 
     _shape = _naxis[1:]
     _shape.reverse()
-    _code = fits.hdu.ImageHDU.NumCode[_bitpix]
+    _code = fits.BITPIX2DTYPE[_bitpix]
     _bscale = phdr.get('BSCALE', 1)
     _bzero = phdr.get('BZERO', 0)
     if phdr['DATATYPE'][:10] == 'UNSIGNED*2':

--- a/lib/stsci/tools/swapgeis.py
+++ b/lib/stsci/tools/swapgeis.py
@@ -210,7 +210,7 @@ def byteswap(input,output=None,clobber=True):
 
     _shape = _naxis[1:]
     _shape.reverse()
-    _code = fits.hdu.ImageHDU.NumCode[_bitpix]
+    _code = fits.BITPIX2DTYPE[_bitpix]
     _bscale = phdr.get('BSCALE', 1)
     _bzero = phdr.get('BZERO', 0)
     if phdr['DATATYPE'][:10] == 'UNSIGNED*2':
@@ -377,7 +377,7 @@ def byteswap(input,output=None,clobber=True):
 
     _shape = _naxis[1:]
     _shape.reverse()
-    _code = fits.hdu.ImageHDU.NumCode[_bitpix]
+    _code = fits.BITPIX2DTYPE[_bitpix]
     _bscale = phdr.get('BSCALE', 1)
     _bzero = phdr.get('BZERO', 0)
     if phdr['DATATYPE'][:10] == 'UNSIGNED*2':

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,10 @@ classifier =
 	Programming Language :: Python
 	Topic :: Scientific/Engineering :: Astronomy
 	Topic :: Software Development :: Libraries :: Python Modules
-requires-python = >=2.6
+requires-python = >=2.7
 requires-dist =
-	astropy (>=0.3.1)
-	numpy (>=1.5.1)
+	astropy (>=1.0)
+	numpy (>=1.7)
 
 [files]
 packages_root = lib
@@ -44,4 +44,3 @@ setup_hooks =
 [backwards_compat]
 use_2to3 = False
 zip_safe = False
-


### PR DESCRIPTION
Fix #59 .

It appears that `NumCode` was deprecated a long time ago in astropy/astropy#3916 and removed in astropy/astropy#4993.

**To test this branch**

It is recommended that you switch to a new `conda` environment to test this, which then you can delete when done:

```
conda install d2to1
conda install stsci.distutils

git clone https://github.com/pllim/stsci.tools.git
git checkout fix-geis-conv
python setup.py install
```