### PR TITLE
WIP: deprecate nmpfit

### DIFF
--- a/lib/stsci/tools/gfit.py
+++ b/lib/stsci/tools/gfit.py
@@ -12,15 +12,18 @@ nmpfit.py is a version of mpfit.py which uses numarray.
 """
 from __future__ import absolute_import, division, print_function
 
-import numpy as N
+import numpy as np
 
-from . import numerixenv
 from . import nmpfit
 
-__version__ = '1.0'          # Release version number only
-__vdate__ = '2007-02-20'     # Date of this version
+import warnings
 
-numerixenv.check()
+warnings.warn("GFIT is deprecated - stsci.tools v 3.4.12 is the last version to contain it."
+              "Use astropy.modeling instead.")
+
+__version__ = '2.0'          # Release version number only
+__vdate__ = '2018-02=3-20'     # Date of this version
+
 
 
 def _gauss_funct(p, fjac = None, x = None, y=None, err=None,
@@ -32,9 +35,9 @@ def _gauss_funct(p, fjac = None, x = None, y=None, err=None,
     """
     if p[2] != 0.0:
         Z = (x - p[1]) / p[2]
-        model = p[0]*N.e ** (-Z**2 / 2.0)
+        model = p[0] * np.e ** (-Z ** 2 / 2.0)
     else:
-        model = N.zeros(N.size(x))
+        model = np.zeros(np.size(x))
 
     status = 0
     if weights is not None:
@@ -47,7 +50,7 @@ def _gauss_funct(p, fjac = None, x = None, y=None, err=None,
         return [status, (y - model) / err]
 
     else:
-        return [status, y-model]
+        return [status, y - model]
 
 
 def gfit1d(y, x=None, err = None, weights=None, par=None, parinfo=None,
@@ -90,27 +93,24 @@ def gfit1d(y, x=None, err = None, weights=None, par=None, parinfo=None,
     [10.         15.          1.41421356]
 
     """
-    if numerixenv.check_input(x) or numerixenv.check_input(y):
-        raise ValueError("Input is a NumArray array. This version of %s requires a Numpy array\n" % __name__)
-
-    y = y.astype(N.float)
+    y = y.astype(np.float)
     if weights is not None:
-        weights = weights.astype(N.float)
+        weights = weights.astype(np.float)
     if err is not None:
-        err = err.astype(N.float)
-    if x is None and len(y.shape)==1 :
-        x = N.arange(len(y)).astype(N.float)
+        err = err.astype(np.float)
+    if x is None and len(y.shape) == 1:
+        x = np.arange(len(y)).astype(np.float)
     if x.shape != y.shape:
         print("input arrays X and Y must be of equal shape.\n")
         return
 
-    fa = {'x':x, 'y':y, 'err':err, 'weights':weights}
+    fa = {'x': x, 'y': y, 'err': err, 'weights': weights}
 
     if par is not None:
         p = par
     else:
         ysigma = y.std()
-        ind = N.nonzero(y > ysigma)[0]
+        ind = np.nonzero(y > ysigma)[0]
         if len(ind) != 0:
             xind = int(ind.mean())
             p2 = x[xind]
@@ -123,15 +123,16 @@ def gfit1d(y, x=None, err = None, weights=None, par=None, parinfo=None,
             if (ymax - ymean) > (abs(ymin - ymean)):
                 p1 = ymax
             else: p1 = ymin
-            ind = (N.nonzero(y == p1))[0]
+            ind = (np.nonzero(y == p1))[0]
             p2 = x.mean()
             p3 = 1.
 
 
         p = [p1, p2, p3]
-    m=nmpfit.mpfit(_gauss_funct, p,parinfo = parinfo, functkw=fa,
-maxiter=maxiter, quiet=quiet)
-    if (m.status <=0): print('error message = ', m.errmsg)
+    #m = nmpfit.mpfit(_gauss_funct, p,parinfo = parinfo, functkw=fa,
+#maxiter=maxiter, quiet=quiet)
+    m = lfit(gauss_model, maxiter=maxiter, disp=quiet)
+    if (m.status <= 0): print('error message = ', m.errmsg)
     return m
 
 

--- a/lib/stsci/tools/gfit.py
+++ b/lib/stsci/tools/gfit.py
@@ -129,9 +129,8 @@ def gfit1d(y, x=None, err = None, weights=None, par=None, parinfo=None,
 
 
         p = [p1, p2, p3]
-    #m = nmpfit.mpfit(_gauss_funct, p,parinfo = parinfo, functkw=fa,
-#maxiter=maxiter, quiet=quiet)
-    m = lfit(gauss_model, maxiter=maxiter, disp=quiet)
+    m = nmpfit.mpfit(_gauss_funct, p,parinfo = parinfo, functkw=fa,
+    maxiter=maxiter, quiet=quiet)
     if (m.status <= 0): print('error message = ', m.errmsg)
     return m
 

--- a/lib/stsci/tools/gfit.py
+++ b/lib/stsci/tools/gfit.py
@@ -22,7 +22,7 @@ warnings.warn("GFIT is deprecated - stsci.tools v 3.4.12 is the last version to 
               "Use astropy.modeling instead.")
 
 __version__ = '2.0'          # Release version number only
-__vdate__ = '2018-02=3-20'     # Date of this version
+__vdate__ = '2018-04-20'     # Date of this version
 
 
 
@@ -87,8 +87,8 @@ def gfit1d(y, x=None, err = None, weights=None, par=None, parinfo=None,
 
     Examples
     --------
-    >>> x=N.arange(10,20, 0.1)
-    >>> y= 10*N.e**(-(x-15)**2/4)
+    >>> x = np.arange(10,20, 0.1)
+    >>> y= 10*np.e**(-(x-15)**2/4)
     >>> print(gfit1d(y,x=x, maxiter=20,quiet=1).params)
     [10.         15.          1.41421356]
 

--- a/lib/stsci/tools/linefit.py
+++ b/lib/stsci/tools/linefit.py
@@ -8,12 +8,9 @@ Y = b0 + b1* X
 :version: '1.0 (2007-02-20)'
 
 """
-from __future__ import absolute_import, division, print_function  # confidence high
+from __future__ import absolute_import, division, print_function
 
 import numpy as N
-
-from . import numerixenv
-numerixenv.check()
 
 __version__ = '1.0'          # Release version number only
 __vdate__ = '2007-02-20'     # Date of this version
@@ -45,9 +42,6 @@ def linefit(x, y, weights=None):
     >>> around(linefit(x,y), decimals=5)
     array([1.42564, 0.31579])
     """
-
-    if numerixenv.check_input(x) or numerixenv.check_input(y):
-        raise ValueError("Input is a NumArray array. This version of %s requires a Numpy array\n" % __name__)
 
     if len(x) != len(y):
         print("Error: X and Y must have equal size\n")

--- a/lib/stsci/tools/nmpfit.py
+++ b/lib/stsci/tools/nmpfit.py
@@ -2,7 +2,13 @@
 Python/Numeric version of this module was called mpfit. This version was modified to use numpy.
 """
 from __future__ import division, print_function # confidence medium
+
 __version__ = '0.2'
+
+import warnings
+
+warnings.warn("NMPFIT is deprecated - stsci.tools v 3.4.12 i sthe last version to contain it."
+
 
 """
 Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
@@ -2242,7 +2248,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         if self.debug:
             print('Entering calc_covar...')
 
-        if numpy.rank(rr) != 2:
+        if rr.ndim != 2:
             print('ERROR: r must be a two-dimensional matrix')
             return(-1)
 

--- a/lib/stsci/tools/nmpfit.py
+++ b/lib/stsci/tools/nmpfit.py
@@ -7,7 +7,7 @@ __version__ = '0.2'
 
 import warnings
 
-warnings.warn("NMPFIT is deprecated - stsci.tools v 3.4.12 i sthe last version to contain it."
+warnings.warn("NMPFIT is deprecated - stsci.tools v 3.4.12 is the last version to contain it.")
 
 
 """


### PR DESCRIPTION
The goal is to remove this module. The only place it's used is in stistools.mktrace. It should be replaced with astropy.modeling. The two changes should be somewhat coordinated.

Fix #72