### PR TITLE
Fix logger to not add extraneous empty lines

### DIFF
--- a/lib/stsci/tools/logutil.py
+++ b/lib/stsci/tools/logutil.py
@@ -117,7 +117,7 @@ if not PY3K:
 else:
     import builtins
     def global_logging_raw_input(prompt):
-        retval = builtins._original_raw_input(prompt)        
+        retval = builtins._original_raw_input(prompt)
         if isinstance(sys.stdout, StreamTeeLogger):
             sys.stdout.log_orig(str(prompt) + retval, echo=False)
         return retval
@@ -237,16 +237,10 @@ class StreamTeeLogger(logging.Logger):
 
             # For each line in the buffer ending with \n, output that line to
             # the logger
-            begin = 0
-            end = message.find('\n', begin) + 1
-            while end > begin:
-                if self.buffer:
-                    self.log_orig(self.buffer, echo=True)
-                    self.buffer = ''
-                self.log_orig(message[begin:end].rstrip(), echo=True)
-                begin = end
-                end = message.find('\n', begin) + 1
-            self.buffer = self.buffer + message[begin:]
+            msgs = (self.buffer + message).split('\n')
+            self.buffer = msgs.pop(-1)
+            for m in msgs:
+                self.log_orig(m, echo=True)
         finally:
             self.__thread_local_ctx.write_count -= 1
 


### PR DESCRIPTION
This PR fixes the issue of extra empty lines being added by the logger to the log output. This issue was described in https://github.com/spacetelescope/stsci.tools/issues/22 I think the wrong logic was implemented in https://github.com/spacetelescope/stsci.tools/commit/404ad36b9df482c992e644e0fc9b25eae2aa30d7#diff-7c2bf91cb9aecb24deef0bbe77a0aace when transitioning to `StringIO`.

With the changes from this PR, I no longer see extra empty lines in the log file. This reduces the _length_ roughly by half.

CC: @jhunkeler 