### PR TITLE
pytest 4.x: Refactor test_minmatch

### DIFF
--- a/lib/stsci/tools/tests/test_minmatch.py
+++ b/lib/stsci/tools/tests/test_minmatch.py
@@ -62,7 +62,7 @@ def test_getall(mmd):
 
 def test_getall_returns_expected_values(mmd):
     result = mmd.getall('t')
-    assert result == [x for x in BASEVALUES]
+    assert sorted(result) == [x for x in BASEVALUES]
 
 
 def test_del_key(mmd):

--- a/lib/stsci/tools/tests/test_minmatch.py
+++ b/lib/stsci/tools/tests/test_minmatch.py
@@ -9,18 +9,6 @@ BASEVALUES = tuple([1, 2, 10])
 
 
 @pytest.fixture
-def mmd_keys():
-    keys = list(BASEKEYS)
-    return keys
-
-
-@pytest.fixture
-def mmd_values():
-    values = list(BASEVALUES)
-    return values
-
-
-@pytest.fixture
 def mmd():
     d = MinMatchDict()
     for value in zip(*[BASEKEYS, BASEVALUES]):
@@ -53,13 +41,13 @@ def test_invalid_key_assignment(mmd):
         mmd['t']
 
 
-def test_dict_sort(mmd, mmd_keys):
+def test_dict_sort(mmd):
     result = [key for key, _ in sorted(mmd.items())]
     assert result[0] == 'ten'
     assert result[-1] == 'text'
 
 
-@pytest.mark.parametrize('key', mmd_keys())
+@pytest.mark.parametrize('key', BASEKEYS)
 def test_get_values(mmd, key):
     assert mmd.get(key)
 
@@ -68,22 +56,21 @@ def test_missing_key_returns_none(mmd):
     assert mmd.get('teq') is None
 
 
-def test_getall(mmd, mmd_values):
+def test_getall(mmd):
     return mmd.getall('t')
 
 
-def test_getall_returns_expected_values(mmd, mmd_values):
+def test_getall_returns_expected_values(mmd):
     result = mmd.getall('t')
-    for value in mmd_values:
-        assert value in result
+    assert result == [x for x in BASEVALUES]
 
 
 def test_del_key(mmd):
     del mmd['test']
 
 
-def test_del_keys(mmd, mmd_keys):
-    for key in mmd_keys:
+def test_del_keys(mmd):
+    for key in BASEKEYS:
         del mmd[key]
 
 
@@ -92,8 +79,8 @@ def test_clear_dict(mmd):
     assert mmd == dict()
 
 
-def test_has_key(mmd, mmd_keys):
-    for key in mmd_keys:
+def test_has_key(mmd):
+    for key in BASEKEYS:
         # Ditch last character in string
         if len(key) > 3:
             key = key[:-1]
@@ -101,13 +88,13 @@ def test_has_key(mmd, mmd_keys):
         assert mmd.has_key(key, exact=False)
 
 
-def test_has_key_exact(mmd, mmd_keys):
-    for key in mmd_keys:
+def test_has_key_exact(mmd):
+    for key in BASEKEYS:
         assert mmd.has_key(key, exact=True)
 
 
-def test_key_in_dict(mmd, mmd_keys):
-    for key in mmd_keys:
+def test_key_in_dict(mmd):
+    for key in BASEKEYS:
         assert key in mmd
 
 


### PR DESCRIPTION
* Remove `mmd_keys` and `mmd_values` fixtures
* Replace `mmd_*` usage with `BASE*` variables

Fixes: https://github.com/spacetelescope/stsci.tools/issues/88

cc @nden 