### PR TITLE
Fix stis kw

### DIFF
--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -497,14 +497,12 @@ def waiver2mef(sciname, newname=None, convert_dq=True, writefits=True):
                         dqfile.writeto(dqfitsname, overwrite=clobber)
                     else:
                         dqfile.writeto(dqfitsname, clobber=clobber)
-            # Now close input GEIS image, and open writable
-            # handle to output FITS image instead...
-            fimg.close()
-            del fimg
-            # Image re-written as MEF, now it needs its WCS updated
-            #updatewcs.updatewcs(fitsname)
+        # Now close input GEIS image, and open writable
+        # handle to output FITS image instead...
+        fimg.close()
+        del fimg
 
-            fimg = fits.open(fitsname, mode='update', memmap=False)
+        fimg = fits.open(fitsname, mode='update', memmap=False)
 
         return fimg
     except IOError:
@@ -532,7 +530,7 @@ def geis2mef(sciname, convert_dq=True):
         raise IOError("Could not open GEIS input: %s" % sciname)
 
     #check for the existence of a data quality file
-    _dqname = buildNewRootname(sciname, extn='.c1h')
+    _dqname = fileutil.buildNewRootname(sciname, extn='.c1h')
     dqexists = os.path.exists(_dqname)
     if dqexists:
         try:
@@ -545,7 +543,7 @@ def geis2mef(sciname, convert_dq=True):
     # or write out a multi-extension FITS file and return a handle to it
     # User wants to make a FITS copy and update it
     # using the filename they have provided
-    fitsname = buildFITSName(sciname)
+    fitsname = fileutil.buildFITSName(sciname)
 
     # Write out GEIS image as multi-extension FITS.
     fexists = os.path.exists(fitsname)
@@ -561,14 +559,12 @@ def geis2mef(sciname, convert_dq=True):
                     dqfile.writeto(dqfitsname, overwrite=clobber)
                 else:
                     dqfile.writeto(dqfitsname, clobber=clobber)
-        # Now close input GEIS image, and open writable
-        # handle to output FITS image instead...
-        fimg.close()
-        del fimg
-        # Image re-written as MEF, now it needs its WCS updated
-        #updatewcs.updatewcs(fitsname)
+    # Now close input GEIS image, and open writable
+    # handle to output FITS image instead...
+    fimg.close()
+    del fimg
+    fimg = fits.open(fitsname, mode=mode, memmap=memmap)
 
-        fimg = fits.open(fitsname, mode=mode, memmap=memmap)
     return fimg
 
 def countInput(input):

--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -336,9 +336,9 @@ def stisExt2PrimKw(stisfiles):
         if isinstance(sfile, str):
             sfile = fits.open(sfile, mode='udpate')
             toclose = True
-        d = {}
+        #d = {}
         for k in kw_list:
-            d[0].header[k] = d[1].header[k]
+            sfile[0].header[k] = sfile[1].header[k]
         if toclose:
             sfile.close()
 

--- a/lib/stsci/tools/fileutil.py
+++ b/lib/stsci/tools/fileutil.py
@@ -761,6 +761,8 @@ def openImage(filename, mode='readonly', memmap=False, writefits=True,
                 # handle to output FITS image instead...
                 fimg.close()
                 del fimg
+                # Image re-written as MEF, now it needs its WCS updated
+                #updatewcs.updatewcs(fitsname)
 
                 fimg = fits.open(fitsname, mode=mode, memmap=memmap)
 
@@ -813,7 +815,7 @@ def openImage(filename, mode='readonly', memmap=False, writefits=True,
             fimg.close()
             del fimg
             # Image re-written as MEF, now it needs its WCS updated
-            updatewcs.updatewcs(fitsname)
+            #updatewcs.updatewcs(fitsname)
 
             fimg = fits.open(fitsname, mode=mode, memmap=memmap)
 


### PR DESCRIPTION
These changes allow the Drizzlepac tests to pass with the changes to STWCS which convert updatewcs to work with HDUList objects as inputs.  Specifically, the code which converts waiver FITS files (like WFPC2) was modified to be consistent with the HDUList inputs.