### PR TITLE
remove nmpfit in later versions

### DIFF
--- a/lib/stsci/tools/nmpfit.py
+++ b/lib/stsci/tools/nmpfit.py
@@ -7,7 +7,7 @@ __version__ = '0.2'
 
 import warnings
 
-warnings.warn("NMPFIT is deprecated - stsci.tools v 3.4.13 is the last version to contain it.")
+warnings.warn("NMPFIT is deprecated - stsci.tools v 3.5 is the last version to contain it.")
 
 
 """


### PR DESCRIPTION
`nmpfit` shoul dhave been removed in this upcoming release. However the code in `stistools` that uses it has not been updated yet. Changing the deprecation warning to specify a later version of removal.