### PR TITLE
Fix logic in check_exptime

### DIFF
--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -150,17 +150,17 @@ def check_exptime(filelist):
         try:
             exptime = f[0].header['EXPTIME']
         except KeyError:
-            removed_files.append(f or None)
+            removed_files.append(f)
             print("Warning:  There are files without keyword EXPTIME")
             continue
         if exptime <= 0:
-            removed_files.append(f or None)
+            removed_files.append(f)
             print("Warning:  There are files with zero exposure time: keyword EXPTIME = 0.0")
 
     if removed_files != []:
         print("Warning:  Removing the following files from input list")
         for f in removed_files:
-            print('\t',f.filename())
+            print('\t',f.filename() or "")
     return removed_files
 
 def checkNGOODPIX(filelist):
@@ -187,16 +187,16 @@ def checkNGOODPIX(filelist):
         for extn in inputfile:
             if 'EXTNAME' in extn.header and extn.header['EXTNAME'] == 'SCI':
                 ngood += extn.header['NGOODPIX']
+        if (ngood == 0):
+            removed_files.append(inputfile)
         if toclose:
             inputfile.close()
-        if (ngood == 0):
-            removed_files.append(inputfile.filename() or "")
 
     if removed_files != []:
         print("Warning:  Files without valid pixels detected: keyword NGOODPIX = 0.0")
         print("Warning:  Removing the following files from input list")
         for f in removed_files:
-            print('\t',f)
+            print('\t',f.inputfile() or "")
 
     return removed_files
 

--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -150,17 +150,17 @@ def check_exptime(filelist):
         try:
             exptime = f[0].header['EXPTIME']
         except KeyError:
-            removed_files.append(f.filename() or "")
+            removed_files.append(f or None)
             print("Warning:  There are files without keyword EXPTIME")
             continue
         if exptime <= 0:
-            removed_files.append(f.filename() or "")
+            removed_files.append(f or None)
             print("Warning:  There are files with zero exposure time: keyword EXPTIME = 0.0")
 
     if removed_files != []:
         print("Warning:  Removing the following files from input list")
         for f in removed_files:
-            print('\t',f)
+            print('\t',f.filename())
     return removed_files
 
 def checkNGOODPIX(filelist):

--- a/lib/stsci/tools/check_files.py
+++ b/lib/stsci/tools/check_files.py
@@ -196,7 +196,7 @@ def checkNGOODPIX(filelist):
         print("Warning:  Files without valid pixels detected: keyword NGOODPIX = 0.0")
         print("Warning:  Removing the following files from input list")
         for f in removed_files:
-            print('\t',f.inputfile() or "")
+            print('\t',f.filename() or "")
 
     return removed_files
 

--- a/lib/stsci/tools/tests/test_check_files.py
+++ b/lib/stsci/tools/tests/test_check_files.py
@@ -10,13 +10,26 @@ from .. import check_files
 
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
+def test_exptime():
+    fobj = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU()])
+    fobj[0].header['INSTRUME'] = 'ACS'
+    fobj[0].header['filename'] = 'junk.fits'
+    fobj[0].header['EXPTIME'] = 0.0
+
+    assert check_files.check_exptime([fobj]) == [fobj]
+
+    fobj[0].header['EXPTIME'] = 10.0
+
+    assert check_files.check_exptime([fobj]) == []
+
+
 def test_n_goodpix():
     fobj = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU()])
     fobj[0].header['INSTRUME'] = 'ACS'
     fobj[0].header['filename'] = 'junk.fits'
     fobj[1].header['NGOODPIX'] = 0
     fobj[1].name = 'SCI'
-    assert check_files.checkNGOODPIX([fobj]) == ['']
+    assert check_files.checkNGOODPIX([fobj]) == [fobj]
 
     fobj[1].header['NGOODPIX'] = 23
     assert check_files.checkNGOODPIX([fobj]) == []


### PR DESCRIPTION
The logic in check_exptime was setup to remove filenames from the input list.  However, the input list it now gets is always a list of HDUList objects, not filenames.  This code was therefore changed to try to remove the HDUList objects for exposures with exptime==0 instead of the filename.  This problem was identified in HSTDP 2019.2 regression testing, with the fix in this PR being tested against the dataset reported by HSTDP as well as another ASN where exptime was valid. 
