### PR TITLE
Fix crash in TEAL when loading MDRIZTAB parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,62 @@
-RELIC-INFO
-lib/stsci/*/version.py
-*/*/version.py
-__pycache__/
-build/
-dist/
-.eggs/
-.DS_Store
-.pytest_cache
-*.egg-info
-*.pyc
-.DS_Store
-.cache
+# Compiled files
+*.py[cod]
+*.a
 *.o
-*.dylib
 *.so
-*.pyc
+__pycache__
+
+# Other generated files
+*/version.py
+*/cython_version.py
+htmlcov
+.coverage
+MANIFEST
+.ipynb_checkpoints
+
+# Sphinx
+docs/api
+docs/_build/
+
+# WingIDE
+*.wpr
+*.wpu
+
+# Eclipse editor project files
+.project
+.pydevproject
+.settings
+
+# Pycharm editor project files
+.idea
+
+# Packages/installer info
+*.egg
+*.egg-info
+dist/
+build/
+eggs
+.eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+distribute-*.tar.gz
+relic/
+RELIC-INFO
+.pytest_cache
+.cache
+
+# codecov
+.coverage
+*.coverage.*
+
+# Other
+*~
+.settings
+*.dylib
 *.swp
+
+# Mac OSX
+.DS_Store

--- a/lib/stsci/tools/teal_bttn.py
+++ b/lib/stsci/tools/teal_bttn.py
@@ -58,8 +58,10 @@ class TealActionParButton(eparoption.ActionEparButton):
                                      tealGui, code)
             # done
             tealGui.debug('Finished: "'+self.getButtonLabel()+'"')
+
         except Exception as ex:
-            msg = 'Error executing: "'+self.getButtonLabel()+'"\n'+ex.message
+            msg = 'Error executing: {}\n{}"'.format(
+                self.getButtonLabel(), ex.args[0])
             msgFull = msg+'\n'+''.join(traceback.format_exc())
             msgFull+= "CODE:\n"+code
             if tealGui:


### PR DESCRIPTION
Fixes a crash in TEAL when user attempts to load `MDRIZTAB` parameters in `astrodrizzle` but the `*_mdz.fits` file does not exist.