### PR TITLE
Pin to astropy 3.1 to avoid io.fits incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires = [
-        'astropy',
+        'astropy<=3.1',
         'numpy',
     ],
     setup_requires = [


### PR DESCRIPTION
An incompatibility with io.fits was introduced in astropy v3.2 that can not be resolved in stsci.tools itself.  This simply insures that we do not use astropy v3.2 until a fix has been released in a new version of astropy.