### PR TITLE
Add decorators for running Travis tests using cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,12 @@ matrix:
         # Try Astropy development version
         - python: 3.6
           env: ASTROPY_VERSION=development SETUP_CMD="test"
+            #EVENT_TYPE='cron'
 
         # PEP8 check
         - python: 3.6
           env: MAIN_CMD="flake8 --count lib/stsci/tools" SETUP_CMD=""
+            #EVENT_TYPE='cron'
 
     allow_failures:
         # PEP8 will fail for numerous reasons. Ignore it.


### PR DESCRIPTION
An attempt at enabling Travis to use cron jobs to run tests on this package on a regular basis.