### PR TITLE
Fix ConstantValueHDUs to work with astropy 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,13 @@
 __pycache__
 
 # Other generated files
-*/version.py
+version.py
 */cython_version.py
 htmlcov
 .coverage
 MANIFEST
 .ipynb_checkpoints
+u40x010hm*.fits
 
 # Sphinx
 docs/api

--- a/lib/stsci/tools/stpyfits.py
+++ b/lib/stsci/tools/stpyfits.py
@@ -72,7 +72,9 @@ def with_stpyfits(func):
             if not was_enabled:
                 disable_stpyfits()
 
-            _BasicHeader.fromfile = fromfile_orig
+            if ASTROPY_VER_GE32:
+                _BasicHeader.fromfile = fromfile_orig
+
         return retval
     return wrapped_with_stpyfits
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires = [
-        'astropy<=3.1',
+        'astropy',
         'numpy',
     ],
     setup_requires = [


### PR DESCRIPTION
Fix #98. 

The approach I initially suggested cannot work because ones also need the data in the header modification code, which cannot be done inside the descriptor. 
So instead one solution - implemented here - is to monkey patch `_BasicHeader.fromfile` to force the loading of the full header. Not ideal  but at least it works for now, and if you need a better solution on the long term we can think about it.

cc @pllim 