### PR TITLE
Creating Release from 3.6.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,62 @@
-RELIC-INFO
-lib/stsci/*/version.py
-*/*/version.py
-__pycache__/
-build/
-dist/
-.eggs/
-.DS_Store
-.pytest_cache
-*.egg-info
-*.pyc
-.DS_Store
-.cache
+# Compiled files
+*.py[cod]
+*.a
 *.o
-*.dylib
 *.so
-*.pyc
+__pycache__
+
+# Other generated files
+*/version.py
+*/cython_version.py
+htmlcov
+.coverage
+MANIFEST
+.ipynb_checkpoints
+
+# Sphinx
+docs/api
+docs/_build/
+
+# WingIDE
+*.wpr
+*.wpu
+
+# Eclipse editor project files
+.project
+.pydevproject
+.settings
+
+# Pycharm editor project files
+.idea
+
+# Packages/installer info
+*.egg
+*.egg-info
+dist/
+build/
+eggs
+.eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+distribute-*.tar.gz
+relic/
+RELIC-INFO
+.pytest_cache
+.cache
+
+# codecov
+.coverage
+*.coverage.*
+
+# Other
+*~
+.settings
+*.dylib
 *.swp
+
+# Mac OSX
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,13 @@
 __pycache__
 
 # Other generated files
-*/version.py
+version.py
 */cython_version.py
 htmlcov
 .coverage
 MANIFEST
 .ipynb_checkpoints
+u40x010hm*.fits
 
 # Sphinx
 docs/api

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.6
+  install:
+     requirements: .rtd-environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,8 +6,8 @@ version: 2
 
 python:
   version: 3.6
+  system_packages: true
   install:
-    - system_packages: true
     - requirements: .rtd-environment.yml
     - method: setuptools
       path: stsci.tools

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,4 +10,4 @@ python:
   install:
     - requirements: .rtd-environment.yml
     - method: setuptools
-      path: stsci.tools
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,4 +7,7 @@ version: 2
 python:
   version: 3.6
   install:
+    - system_packages: true
     - requirements: .rtd-environment.yml
+    - method: setuptools
+      path: stsci.tools

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,4 +7,4 @@ version: 2
 python:
   version: 3.6
   install:
-     requirements: .rtd-environment.yml
+    - requirements: .rtd-environment.yml

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,6 +1,2 @@
-name: stsci.tools
-
-dependencies:
-  - python>=3
-  - numpy
-  - astropy
+numpy
+astropy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: xenial
+
 os:
     - linux
 
@@ -31,26 +33,24 @@ matrix:
     fast_finish: true
 
     include:
-        # TODO: Bump Python to 3.6 when pipeline upgrades to it.
-        - python: 3.5
+        - python: 3.6
           env: ASTROPY_VERSION=stable SETUP_CMD="test"
 
-        # TODO: Bump Astropy version to LTS in the future?
         # Do a test in Python 2.
         - python: 2.7
-          env: ASTROPY_VERSION=1.3 SETUP_CMD="test"
+          env: NUMPY_VERSION=1.15 ASTROPY_VERSION=lts SETUP_CMD="test"
 
         # Try Astropy development version
-        - python: 3.6
+        - python: 3.7
           env: ASTROPY_VERSION=development SETUP_CMD="test"
 
         # PEP8 check
-        - python: 3.6
+        - python: 3.7
           env: MAIN_CMD="flake8 --count lib/stsci/tools" SETUP_CMD=""
 
     allow_failures:
         # PEP8 will fail for numerous reasons. Ignore it.
-        - python: 3.6
+        - python: 3.7
           env: MAIN_CMD="flake8 --count lib/stsci/tools" SETUP_CMD=""
 
 before_install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,24 @@
+.. _change_log:
+
+=======================
+stsci.tools change log
+=======================
+
+The version of stsci.tools can be identified using ::
+
+> python
+>>> import stsci.tools
+>>> stsci.tools.__version__
+
+The following notes provide some details on what has been revised for each
+version in reverse chronological order (most recent version at the top
+of the list).
+
+3.6.0 (2019-07-17)
+------------------
+
+- Update stpyfits to be compatible with astropy v3.2.1 [#101]
+
+- Fixes a crash in TEAL when loading MDRIZTAB parameters in astrodrizzle [#95]
+
+- Use raw string in regex in irafutils.csvSplit [#85]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE.md
 include RELIC-INFO
 exclude lib/stsci/tools/version.py
 recursive-include lib/stsci/tools/tests *

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+def pytest_report_header(config):
+    """Report dependency versions"""
+    import numpy
+    import astropy
+
+    return 'numpy: {}\nastropy: {}'.format(
+        numpy.__version__, astropy.__version__)

--- a/lib/stsci/tools/bitmask.py
+++ b/lib/stsci/tools/bitmask.py
@@ -244,7 +244,7 @@ def interpret_bit_flags(bit_flags, flip_bits=None):
 
 def bitfield_to_boolean_mask(bitfield, ignore_flags=0, flip_bits=None,
                              good_mask_value=True, dtype=np.bool_):
-    """
+    r"""
     bitfield_to_boolean_mask(bitfield, ignore_flags=None, flip_bits=None, \
 good_mask_value=True, dtype=numpy.bool\_)
     Converts an array of bit fields to a boolean (or integer) mask array
@@ -512,7 +512,7 @@ def interpret_bits_value(val):
 @deprecated(since='3.4.6', message='', name='bitmask2mask',
             alternative='bitfield_to_boolean_mask')
 def bitmask2mask(bitmask, ignore_bits, good_mask_value=1, dtype=np.bool_):
-    """
+    r"""
     bitmask2mask(bitmask, ignore_bits, good_mask_value=1, dtype=numpy.bool\_)
     Interprets an array of bit flags and converts it to a "binary" mask array.
     This function is particularly useful to convert data quality arrays to

--- a/lib/stsci/tools/irafutils.py
+++ b/lib/stsci/tools/irafutils.py
@@ -292,7 +292,7 @@ def setWritePrivs(fname, makeWritable, ignoreErrors=False):
 
 def removeEscapes(value, quoted=0):
 
-    """Remove escapes from in front of quotes (which IRAF seems to
+    r"""Remove escapes from in front of quotes (which IRAF seems to
     just stick in for fun sometimes.)  Remove \-newline too.
     If quoted is true, removes all blanks following \-newline
     (which is a nasty thing IRAF does for continuations inside

--- a/lib/stsci/tools/irafutils.py
+++ b/lib/stsci/tools/irafutils.py
@@ -187,7 +187,7 @@ def csvSplit(line, delim=',', allowEol=True):
 # Since these strings will be short, the fastest method is re.search()
 _re_sq = re.compile(r"'")
 _re_dq = re.compile(r'"')
-_re_comma_sq_dq = re.compile('[,\'"]')
+_re_comma_sq_dq = re.compile(r'[,\'"]')
 
 def _getCharsUntil(buf, stopChar, branchForQuotes, allowEol):
 

--- a/lib/stsci/tools/stpyfits.py
+++ b/lib/stsci/tools/stpyfits.py
@@ -22,6 +22,7 @@ from distutils.version import LooseVersion
 
 PY3K = sys.version_info[0] > 2
 ASTROPY_VER_GE20 = LooseVersion(astropy.__version__) >= LooseVersion('2.0')
+ASTROPY_VER_GE32 = LooseVersion(astropy.__version__) >= LooseVersion('3.2')
 
 STPYFITS_ENABLED = False  # Not threadsafe TODO: (should it be?)
 
@@ -51,6 +52,14 @@ def with_stpyfits(func):
         global STPYFITS_ENABLED
         was_enabled = STPYFITS_ENABLED
         enable_stpyfits()
+        if ASTROPY_VER_GE32:
+            from astropy.io.fits.header import _BasicHeader
+            fromfile_orig = _BasicHeader.fromfile
+
+            def fromfile_patch(*args):
+                raise Exception
+            _BasicHeader.fromfile = fromfile_patch
+
         try:
             # BUG: Forcefully disable lazy loading.
             # Lazy loading breaks ability to initialize ConstantValueHDUs
@@ -62,6 +71,10 @@ def with_stpyfits(func):
             # Only disable stpyfits if it wasn't already enabled
             if not was_enabled:
                 disable_stpyfits()
+
+            if ASTROPY_VER_GE32:
+                _BasicHeader.fromfile = fromfile_orig
+
         return retval
     return wrapped_with_stpyfits
 

--- a/lib/stsci/tools/teal_bttn.py
+++ b/lib/stsci/tools/teal_bttn.py
@@ -58,8 +58,10 @@ class TealActionParButton(eparoption.ActionEparButton):
                                      tealGui, code)
             # done
             tealGui.debug('Finished: "'+self.getButtonLabel()+'"')
+
         except Exception as ex:
-            msg = 'Error executing: "'+self.getButtonLabel()+'"\n'+ex.message
+            msg = 'Error executing: {}\n{}"'.format(
+                self.getButtonLabel(), ex.args[0])
             msgFull = msg+'\n'+''.join(traceback.format_exc())
             msgFull+= "CODE:\n"+code
             if tealGui:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,0 @@
-conda:
-  file: .rtd-environment.yml
-
-python:
-  setup_py_install: true
-
-formats:
-  - none

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires = [
-        'astropy<=3.1',
+        'astropy',
         'numpy',
     ],
     setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires = [
-        'astropy',
+        'astropy<=3.1',
         'numpy',
     ],
     setup_requires = [


### PR DESCRIPTION
This PR defines what would be released as part of the 'quick fix' release HSTDP-2019.3b as stsci.tools version 3.6.0.