### PR TITLE
Improve bitmask compatibility with numpy 1.21

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ of the list).
 
 - ``astropy`` 2 or later is now required. [#121]
 
+- Improved compatibility of the ``bitmask`` module with ``numpy 1.21``. [#136]
+
 3.6.0 (2019-07-17)
 ------------------
 

--- a/lib/stsci/tools/bitmask.py
+++ b/lib/stsci/tools/bitmask.py
@@ -416,7 +416,7 @@ def bitfield_to_boolean_mask(bitfield, ignore_flags=0, flip_bits=None,
     ignore_mask = ignore_mask & SUPPORTED_FLAGS
 
     # invert the "ignore" mask:
-    ignore_mask = np.bitwise_not(ignore_mask, dtype=bitfield.dtype,
+    ignore_mask = np.bitwise_not(ignore_mask, dtype=bitfield.dtype.type,
                                  casting='unsafe')
 
     mask = np.empty_like(bitfield, dtype=np.bool_)


### PR DESCRIPTION
Currently `numpy 1.21.1` raises an exception (should have been a deprecation warning) when running `bitmask` code due to the following change: https://numpy.org/doc/stable/release/1.21.0-notes.html#changes-to-dtype-and-signature-arguments-in-ufuncs. This PR improves compatibility with `numpy>=1.21.0`.

Also see https://github.com/numpy/numpy/issues/19625

This PR improves compatibility with `numpy 1.21.*`