### PR TITLE
Use Python 'int' and 'float' type to avoid numpy warnings

### DIFF
--- a/lib/stsci/tools/gfit.py
+++ b/lib/stsci/tools/gfit.py
@@ -89,13 +89,13 @@ def gfit1d(y, x=None, err=None, weights=None, par=None, parinfo=None,
     [10.         15.          1.41421356]
 
     """
-    y = y.astype(np.float)
+    y = y.astype(float)
     if weights is not None:
-        weights = weights.astype(np.float)
+        weights = weights.astype(float)
     if err is not None:
-        err = err.astype(np.float)
+        err = err.astype(float)
     if x is None and len(y.shape) == 1:
-        x = np.arange(len(y)).astype(np.float)
+        x = np.arange(len(y)).astype(float)
     if x.shape != y.shape:
         print("input arrays X and Y must be of equal shape.\n")
         return

--- a/lib/stsci/tools/linefit.py
+++ b/lib/stsci/tools/linefit.py
@@ -8,7 +8,7 @@ Y = b0 + b1* X
 :version: '1.0 (2007-02-20)'
 
 """
-import numpy as N
+import numpy as np
 
 __version__ = '1.0'          # Release version number only
 __vdate__ = '2007-02-20'     # Date of this version
@@ -31,12 +31,12 @@ def linefit(x, y, weights=None):
     --------
     >>> import numpy as N
     >>> from numpy.core import around
-    >>> x = N.array([-5, -4 ,-3 ,-2 ,-1, 0, 1, 2, 3, 4, 5])
-    >>> y = N.array([1, 5, 4, 7, 10, 8, 9, 13, 14, 13, 18])
+    >>> x = np.array([-5, -4 ,-3 ,-2 ,-1, 0, 1, 2, 3, 4, 5])
+    >>> y = np.array([1, 5, 4, 7, 10, 8, 9, 13, 14, 13, 18])
     >>> around(linefit(x,y), decimals=5)
     array([9.27273, 1.43636])
-    >>> x = N.array([1.3,1.3,2.0,2.0,2.7,3.3,3.3,3.7,3.7,4.,4.,4.,4.7,4.7,5.,5.3,5.3,5.3,5.7,6.,6.,6.3,6.7])
-    >>> y = N.array([2.3,1.8,2.8,1.5,2.2,3.8,1.8,3.7,1.7,2.8,2.8,2.2,3.2,1.9,1.8,3.5,2.8,2.1,3.4,3.2,3.,3.,5.9])
+    >>> x = np.array([1.3,1.3,2.0,2.0,2.7,3.3,3.3,3.7,3.7,4.,4.,4.,4.7,4.7,5.,5.3,5.3,5.3,5.7,6.,6.,6.3,6.7])
+    >>> y = np.array([2.3,1.8,2.8,1.5,2.2,3.8,1.8,3.7,1.7,2.8,2.8,2.2,3.2,1.9,1.8,3.5,2.8,2.1,3.4,3.2,3.,3.,5.9])
     >>> around(linefit(x,y), decimals=5)
     array([1.42564, 0.31579])
     """
@@ -44,27 +44,27 @@ def linefit(x, y, weights=None):
         print("Error: X and Y must have equal size\n")
         return
     n = len(x)
-    w = N.zeros((n,n)).astype(N.float)
+    w = np.zeros((n,n)).astype(float)
     if weights is None:
-        for i in N.arange(n):
+        for i in np.arange(n):
             w[i,i] = 1
     else:
         if len(weights) != n:
             print("Error: Weights must have the same size as X and Y.\n")
             return
-        for i in N.arange(n):
+        for i in np.arange(n):
             w[i,i] = weights[i]
-    x = x.astype(N.float)
-    y = y.astype(N.float)
+    x = x.astype(float)
+    y = y.astype(float)
     # take the weighted avg for calculatiing the covarince
-    Xavg = N.sum(N.dot(w,x)) / N.sum(w.diagonal())
-    Yavg = N.sum(N.dot(w,y)) / N.sum(w.diagonal())
+    Xavg = np.sum(np.dot(w,x)) / np.sum(w.diagonal())
+    Yavg = np.sum(np.dot(w,y)) / np.sum(w.diagonal())
 
     xm = x - Xavg
-    xmt = N.transpose(xm)
+    xmt = np.transpose(xm)
     ym = y - Yavg
 
-    b1 = N.dot(xmt,N.dot(w,ym)) / N.dot(xmt ,N.dot(w,xm))
+    b1 = np.dot(xmt,np.dot(w,ym)) / np.dot(xmt ,np.dot(w,xm))
     b0 = Yavg - b1 * Xavg
 
     return b0, b1

--- a/lib/stsci/tools/nmpfit.py
+++ b/lib/stsci/tools/nmpfit.py
@@ -1,5 +1,5 @@
 """
-Python/Numeric version of this module was called mpfit. This version was modified to use np.
+Python/Numeric version of this module was called mpfit. This version was modified to use numpy.
 """
 __version__ = '0.2'
 

--- a/lib/stsci/tools/nmpfit.py
+++ b/lib/stsci/tools/nmpfit.py
@@ -1,5 +1,5 @@
 """
-Python/Numeric version of this module was called mpfit. This version was modified to use numpy.
+Python/Numeric version of this module was called mpfit. This version was modified to use np.
 """
 __version__ = '0.2'
 
@@ -145,7 +145,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
                 # stop the calculation.
                 status = 0
                 if (dojac):
-                        pderiv = Numeric.zeros([len(x), len(p)], Numeric.Float)
+                        pderiv = Numeric.zeros([len(x), len(p)], float)
                         for j in range(len(p)):
                         pderiv[:,j] = FGRAD(x, p, j)
                 else:
@@ -282,11 +282,11 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
                                                                                                 EXAMPLE
 
         import mpfit
-        import Numeric
-        x = Numeric.arange(100, Numeric.float)
+        import numpy as np
+        x = np.arange(100, float)
         p0 = [5.7, 2.2, 500., 1.5, 2000.]
-        y = ( p[0] + p[1]*[x] + p[2]*[x**2] + p[3]*Numeric.sqrt(x) +
-                        p[4]*Numeric.log(x))
+        y = ( p[0] + p[1]*[x] + p[2]*[x**2] + p[3]*np.sqrt(x) +
+                        p[4]*np.log(x))
         fa = {'x':x, 'y':y, 'err':err}
         m = mpfit('myfunct', p0, functkw=fa)
         print 'status = ', m.status
@@ -410,7 +410,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
         Translated from MPFIT (Craig Markwardt's IDL package) to Python,
         August, 2002.  Mark Rivers
 """
-import numpy
+import numpy as np
 import types
 
 
@@ -814,7 +814,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 pcor = cov * 0.
                 for i in range(n):
                         for j in range(n):
-                                pcor[i,j] = cov[i,j]/Numeric.sqrt(cov[i,i]*cov[j,j])
+                                pcor[i,j] = cov[i,j]/np.sqrt(cov[i,i]*cov[j,j])
 
         If nocovar is set or MPFIT terminated abnormally, then .covar is set to
         a scalar with value None.
@@ -844,7 +844,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
                 dof = len(x) - len(mpfit.params) # deg of freedom
                 # scaled uncertainties
-                pcerror = mpfit.perror * numpy.sqrt(mpfit.fnorm / dof)
+                pcerror = mpfit.perror * np.sqrt(mpfit.fnorm / dof)
 
         """
         self.niter = 0
@@ -900,9 +900,9 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 return
 
 
-        ## Make sure parameters are numpy arrays of type numpy.float
+        ## Make sure parameters are numpy arrays of type np.float
         #print 'xall', xall, type(xall)
-        xall = numpy.asarray(xall, numpy.float)
+        xall = np.asarray(xall, float)
 
         npar = len(xall)
         self.fnorm  = -1.
@@ -934,17 +934,17 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         qmin = minstep * 0  ## Remove minstep for now!!
         qmax = maxstep != 0
 
-        wh = numpy.nonzero(((qmin!=0.) & (qmax!=0.)) & (maxstep < minstep))
+        wh = np.nonzero(((qmin!=0.) & (qmax!=0.)) & (maxstep < minstep))
 
         #check if it's 1d array?
         if (len(wh[0]) > 0):
             self.errmsg = 'ERROR: MPMINSTEP is greater than MPMAXSTEP'
             return
-        wh = numpy.nonzero((qmin!=0.) & (qmax!=0.))
+        wh = np.nonzero((qmin!=0.) & (qmax!=0.))
         qminmax = len(wh[0] > 0)
 
         ## Finish up the free parameters
-        ifree = (numpy.nonzero(pfixed != 1))[0]
+        ifree = (np.nonzero(pfixed != 1))[0]
         nfree = len(ifree)
         if nfree == 0:
             self.errmsg = 'ERROR: no free parameters'
@@ -952,7 +952,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         ## Compose only VARYING parameters
         self.params = xall      ## self.params is the set of parameters to be returned
-        x = numpy.take(self.params, ifree)  ## x is the set of free parameters
+        x = np.take(self.params, ifree)  ## x is the set of free parameters
 
         ## LIMITED parameters ?
         limited = self.parinfo(parinfo, 'limited', default=[0,0], n=npar)
@@ -960,12 +960,12 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         if limited is not None and limits is not None:
             ## Error checking on limits in parinfo
-            wh = numpy.nonzero((limited[:,0] & (xall < limits[:,0])) |
+            wh = np.nonzero((limited[:,0] & (xall < limits[:,0])) |
                                                                     (limited[:,1] & (xall > limits[:,1])))
             if (len(wh[0]) > 0):
                 self.errmsg = 'ERROR: parameters are not within PARINFO limits'
                 return
-            wh = numpy.nonzero((limited[:,0] & limited[:,1]) &
+            wh = np.nonzero((limited[:,0] & limited[:,1]) &
                                                                     (limits[:,0] >= limits[:,1]) &
                                                                     (pfixed == 0))
             if (len(wh[0]) > 0):
@@ -973,17 +973,17 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 return
 
             ## Transfer structure values to local variables
-            qulim = numpy.take(limited[:,1], ifree)
-            ulim  = numpy.take(limits [:,1], ifree)
-            qllim = numpy.take(limited[:,0], ifree)
-            llim  = numpy.take(limits [:,0], ifree)
+            qulim = np.take(limited[:,1], ifree)
+            ulim  = np.take(limits [:,1], ifree)
+            qllim = np.take(limited[:,0], ifree)
+            llim  = np.take(limits [:,0], ifree)
 
-            wh = numpy.nonzero((qulim!=0.) | (qllim!=0.))
+            wh = np.nonzero((qulim!=0.) | (qllim!=0.))
             if (len(wh[0]) > 0): qanylim = 1
             else: qanylim = 0
         else:
             ## Fill in local variables with dummy values
-            qulim = numpy.zeros(nfree, dtype=n.int8)
+            qulim = np.zeros(nfree, dtype=n.int8)
             ulim  = x * 0.
             qllim = qulim
             llim  = x * 0.
@@ -999,12 +999,12 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         if (rescale != 0):
             self.errmsg = 'ERROR: DIAG parameter scales are inconsistent'
             if (len(diag) < n): return
-            wh = (numpy.nonzero(diag <= 0))[0]
+            wh = (np.nonzero(diag <= 0))[0]
             if (len(wh) > 0): return
             self.errmsg = ''
 
-        # Make sure x is a numpy array of type numpy.float
-        x = numpy.asarray(x, numpy.float64)
+        # Make sure x is a numpy array of type np.float
+        x = np.asarray(x, np.float64)
 
         [self.status, fvec] = self.call(fcn, self.params, functkw)
         if (self.status < 0):
@@ -1030,7 +1030,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         while(1):
 
             ## If requested, call fcn to enable printing of iterates
-            numpy.put(self.params, ifree, x)
+            np.put(self.params, ifree, x)
             if self.qanytied:
                 self.params = self.tie(self.params, ptied)
 
@@ -1054,7 +1054,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                     ## If parameters were changed (grrr..) then re-tie
                     if (max(abs(xnew0-self.params)) > 0):
                         if (self.qanytied): self.params = self.tie(self.params, ptied)
-                        x = numpy.take(self.params, ifree)
+                        x = np.take(self.params, ifree)
 
 
             ## Calculate the jacobian matrix
@@ -1071,20 +1071,20 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             ## Determine if any of the parameters are pegged at the limits
             if qanylim:
                 catch_msg = 'zeroing derivatives of pegged parameters'
-                whlpeg = (numpy.nonzero(qllim & (x == llim)))[0]
+                whlpeg = (np.nonzero(qllim & (x == llim)))[0]
                 nlpeg = len(whlpeg)
-                whupeg = (numpy.nonzero(qulim & (x == ulim)) )[0]
+                whupeg = (np.nonzero(qulim & (x == ulim)) )[0]
                 nupeg = len(whupeg)
                 ## See if any "pegged" values should keep their derivatives
                 if nlpeg > 0:
                     ## Total derivative of sum wrt lower pegged parameters
                     for i in range(nlpeg):
-                        sum = numpy.sum(fvec * fjac[:,whlpeg[i]])
+                        sum = np.sum(fvec * fjac[:,whlpeg[i]])
                         if (sum > 0): fjac[:,whlpeg[i]] = 0
                 if nupeg > 0:
                     ## Total derivative of sum wrt upper pegged parameters
                     for i in range(nupeg):
-                        sum = numpy.sum(fvec * fjac[:,whupeg[i]])
+                        sum = np.sum(fvec * fjac[:,whupeg[i]])
                         if (sum < 0): fjac[:,whupeg[i]] = 0
 
             ## Compute the QR factorization of the jacobian
@@ -1096,8 +1096,8 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             if self.niter == 1:
                 if rescale == 0 or len(diag) < n:
                     diag = wa2.copy()
-                    wh = (numpy.nonzero(diag == 0) )[0]
-                    numpy.put(diag, wh, 1.)
+                    wh = (np.nonzero(diag == 0) )[0]
+                    np.put(diag, wh, 1.)
 
                 ## On the first iteration, calculate the norm of the scaled x
                 ## and initialize the step bound delta
@@ -1116,7 +1116,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                     fj = fjac[j:,lj]
                     wj = wa4[j:]
                     ## *** optimization wa4(j:*)
-                    wa4[j:] = wj - fj * numpy.sum(fj*wj) / temp3
+                    wa4[j:] = wj - fj * np.sum(fj*wj) / temp3
                 fjac[j,lj] = wa1[j]
                 qtf[j] = wa4[j]
             ## From this point on, only the square matrix, consisting of the
@@ -1141,7 +1141,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 for j in range(n):
                     l = ipvt[j]
                     if (wa2[l] != 0):
-                        sum = numpy.sum(fjac[0:j+1,j]*qtf[0:j+1])/self.fnorm
+                        sum = np.sum(fjac[0:j+1,j]*qtf[0:j+1])/self.fnorm
                         gnorm = max([gnorm,abs(sum/wa2[l])])
 
             ## Test for convergence of the gradient norm
@@ -1151,7 +1151,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
             ## Rescale if necessary
             if (rescale == 0):
-                diag = numpy.choose(diag>wa2, (wa2, diag))
+                diag = np.choose(diag>wa2, (wa2, diag))
 
             ## Beginning of the inner loop
             while(1):
@@ -1179,33 +1179,33 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                         ## Do not allow any steps out of bounds
                         catch_msg = 'checking for a step out of bounds'
                         if (nlpeg > 0):
-                            numpy.put(wa1, whlpeg, numpy.clip(
-                                    numpy.take(wa1, whlpeg), 0., max(wa1)))
+                            np.put(wa1, whlpeg, np.clip(
+                                    np.take(wa1, whlpeg), 0., max(wa1)))
                         if (nupeg > 0):
-                            numpy.put(wa1, whupeg, numpy.clip(
-                                    numpy.take(wa1, whupeg), min(wa1), 0.))
+                            np.put(wa1, whupeg, np.clip(
+                                    np.take(wa1, whupeg), min(wa1), 0.))
 
                         dwa1 = abs(wa1) > machep
-                        whl = (numpy.nonzero(((dwa1!=0.) & qllim) & ((x + wa1) < llim)) )[0]
+                        whl = (np.nonzero(((dwa1!=0.) & qllim) & ((x + wa1) < llim)) )[0]
 
                         if (len(whl) > 0):
-                            t = (((numpy.take(llim, whl) - numpy.take(x, whl)) /
-                                            numpy.take(wa1, whl)))
+                            t = (((np.take(llim, whl) - np.take(x, whl)) /
+                                            np.take(wa1, whl)))
 
                             alpha = min(alpha, min(t))
-                        whu = (numpy.nonzero(((dwa1!=0.) & qulim) & ((x + wa1) > ulim)) )[0]
+                        whu = (np.nonzero(((dwa1!=0.) & qulim) & ((x + wa1) > ulim)) )[0]
                         if (len(whu) > 0):
-                            t = ((numpy.take(ulim, whu) - numpy.take(x, whu)) /
-                                            numpy.take(wa1, whu))
+                            t = ((np.take(ulim, whu) - np.take(x, whu)) /
+                                            np.take(wa1, whu))
                             alpha = min(alpha, min(t))
 
                     ## Obey any max step values.
                     if (qminmax):
                         nwa1 = wa1 * alpha
-                        whmax = (numpy.nonzero((qmax != 0.) & (maxstep > 0)) )[0]
+                        whmax = (np.nonzero((qmax != 0.) & (maxstep > 0)) )[0]
                         if (len(whmax) > 0):
-                            mrat = max(numpy.take(nwa1, whmax) /
-                                                            numpy.take(maxstep, whmax))
+                            mrat = max(np.take(nwa1, whmax) /
+                                                            np.take(maxstep, whmax))
                             if (mrat > 1): alpha = alpha / mrat
 
                     ## Scale the resulting vector
@@ -1214,10 +1214,10 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
                     ## Adjust the final output values.  If the step put us exactly
                     ## on a boundary, make sure it is exact.
-                    wh = (numpy.nonzero((qulim!=0.) & (wa2 >= ulim*(1-machep))) )[0]
-                    if (len(wh) > 0): numpy.put(wa2, wh, numpy.take(ulim, wh))
-                    wh = (numpy.nonzero((qllim!=0.) & (wa2 <= llim*(1+machep))) )[0]
-                    if (len(wh) > 0): numpy.put(wa2, wh, numpy.take(llim, wh))
+                    wh = (np.nonzero((qulim!=0.) & (wa2 >= ulim*(1-machep))) )[0]
+                    if (len(wh) > 0): np.put(wa2, wh, np.take(ulim, wh))
+                    wh = (np.nonzero((qllim!=0.) & (wa2 <= llim*(1+machep))) )[0]
+                    if (len(wh) > 0): np.put(wa2, wh, np.take(llim, wh))
                 # endelse
                 wa3 = diag * wa1
                 pnorm = self.enorm(wa3)
@@ -1225,7 +1225,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 ## On the first iteration, adjust the initial step bound
                 if (self.niter == 1): delta = min([delta,pnorm])
 
-                numpy.put(self.params, ifree, wa2)
+                np.put(self.params, ifree, wa2)
 
                 ## Evaluate the function at x+p and calculate its norm
                 mperr = 0
@@ -1250,7 +1250,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 ## Remember, alpha is the fraction of the full LM step actually
                 ## taken
                 temp1 = self.enorm(alpha*wa3)/self.fnorm
-                temp2 = (numpy.sqrt(alpha*par)*pnorm)/self.fnorm
+                temp2 = (np.sqrt(alpha*par)*pnorm)/self.fnorm
                 prered = temp1*temp1 + (temp2*temp2)/0.5
                 dirder = -(temp1*temp1 + temp2*temp2)
 
@@ -1318,7 +1318,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         if (nfree == 0):
             self.params = xall.copy()
         else:
-            numpy.put(self.params, ifree, x)
+            np.put(self.params, ifree, x)
 
         if nprint > 0 and self.status > 0:
             catch_msg = 'calling ' + str(fcn)
@@ -1335,7 +1335,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         ## (very carefully) set the covariance matrix COVAR
         if (self.status > 0 and nocovar == 0 and n is not None
             and fjac is not None and ipvt is not None):
-            sz = numpy.shape(fjac)
+            sz = np.shape(fjac)
 
             if (n > 0 and sz[0] >= n and sz[1] >= n and len(ipvt) >= n):
                 catch_msg = 'computing the covariance matrix'
@@ -1345,20 +1345,20 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
                 ## Fill in actual covariance matrix, accounting for fixed
                 ## parameters.
-                self.covar = numpy.zeros([nn, nn], numpy.float)
+                self.covar = np.zeros([nn, nn], float)
 
                 for i in range(n):
                     indices = ifree+ifree[i]*nn
-                    numpy.put(self.covar, indices, cv[:,i])
-                    #numpy.put(self.covar, i, cv[:,i])
+                    np.put(self.covar, indices, cv[:,i])
+                    #np.put(self.covar, i, cv[:,i])
 
                 ## Compute errors in parameters
                 catch_msg = 'computing parameter errors'
-                self.perror = numpy.zeros(nn, numpy.float)
-                d = numpy.diagonal(self.covar)
-                wh = (numpy.nonzero(d >= 0) )[0]
+                self.perror = np.zeros(nn, float)
+                d = np.diagonal(self.covar)
+                wh = (np.nonzero(d >= 0) )[0]
                 if len(wh) > 0:
-                    numpy.put(self.perror, wh, numpy.sqrt(numpy.take(d, wh)))
+                    np.put(self.perror, wh, np.sqrt(np.take(d, wh)))
         return
 
 
@@ -1436,9 +1436,9 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         test = default
         if type(default) == list: test=default[0]
         if type(test) == int:
-            values = numpy.asarray(values, dtype=numpy.int)
+            values = np.asarray(values, dtype=int)
         elif type(test) == float:
-            values = numpy.asarray(values, dtype=numpy.float)
+            values = np.asarray(values, dtype=float)
 
         return(values)
 
@@ -1461,7 +1461,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 ## Apply the damping if requested.  This replaces the residuals
                 ## with their hyperbolic tangent.  Thus residuals larger than
                 ## DAMP are essentially clipped.
-                f = numpy.tanh(f/self.damp)
+                f = np.tanh(f/self.damp)
             return([status, f])
 
         else:
@@ -1480,7 +1480,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         # Very simple-minded sum-of-squares
         if (self.fastnorm):
-            ans = numpy.sqrt(numpy.sum(vec*vec))
+            ans = np.sqrt(np.sum(vec*vec))
         else:
             agiant = self.machar.rgiant / len(vec)
             adwarf = self.machar.rdwarf * len(vec)
@@ -1492,9 +1492,9 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             mx = max(abs(mx), abs(mn))
             if mx == 0: return(vec[0]*0.)
             if mx > agiant or mx < adwarf:
-                ans = mx * numpy.sqrt(numpy.sum((vec/mx)*(vec/mx)))
+                ans = mx * np.sqrt(np.sum((vec/mx)*(vec/mx)))
             else:
-                ans = numpy.sqrt(numpy.sum(vec*vec))
+                ans = np.sqrt(np.sum(vec*vec))
 
         return(ans)
 
@@ -1512,22 +1512,22 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             xall = x
 
         if ifree is None:
-            ifree = numpy.arange(len(xall))
+            ifree = np.arange(len(xall))
 
         if step is None:
             step = x * 0.
 
         nall = len(xall)
 
-        eps = numpy.sqrt(max([epsfcn, machep]))
+        eps = np.sqrt(max([epsfcn, machep]))
         m = len(fvec)
         n = len(x)
 
         ## Compute analytical derivative if requested
         if (autoderivative == 0):
             mperr = 0
-            fjac = numpy.zeros(nall, numpy.float)
-            numpy.put(fjac, ifree, 1.0)  ## Specify which parameters need derivatives
+            fjac = np.zeros(nall, float)
+            np.put(fjac, ifree, 1.0)  ## Specify which parameters need derivatives
             [status, fp] = self.call(fcn, xall, functkw, fjac=fjac)
 
             if len(fjac) != m*nall:
@@ -1545,37 +1545,37 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 fjac.shape = [m, n]
                 return(fjac)
 
-        fjac = numpy.zeros([m, n], numpy.float)
+        fjac = np.zeros([m, n], float)
 
         h = eps * abs(x)
 
         ## if STEP is given, use that
         if step is not None:
-            stepi = numpy.take(step, ifree)
-            wh = (numpy.nonzero(stepi > 0) )[0]
-            if (len(wh) > 0): numpy.put(h, wh, numpy.take(stepi, wh))
+            stepi = np.take(step, ifree)
+            wh = (np.nonzero(stepi > 0) )[0]
+            if (len(wh) > 0): np.put(h, wh, np.take(stepi, wh))
 
         ## if relative step is given, use that
         if (len(dstep) > 0):
-            dstepi = numpy.take(dstep, ifree)
-            wh = (numpy.nonzero(dstepi > 0) )[0]
-            if len(wh) > 0: numpy.put(h, wh, abs(numpy.take(dstepi,wh)*numpy.take(x,wh)))
+            dstepi = np.take(dstep, ifree)
+            wh = (np.nonzero(dstepi > 0) )[0]
+            if len(wh) > 0: np.put(h, wh, abs(np.take(dstepi,wh)*np.take(x,wh)))
 
         ## In case any of the step values are zero
-        wh = (numpy.nonzero(h == 0) )[0]
-        if len(wh) > 0: numpy.put(h, wh, eps)
+        wh = (np.nonzero(h == 0) )[0]
+        if len(wh) > 0: np.put(h, wh, eps)
 
         ## Reverse the sign of the step if we are up against the parameter
         ## limit, or if the user requested it.
         #mask = dside == -1
-        mask = numpy.take((dside == -1), ifree)
+        mask = np.take((dside == -1), ifree)
 
         if len(ulimited) > 0 and len(ulimit) > 0:
             #mask = mask or (ulimited and (x > ulimit-h))
             mask = mask | (ulimited & (x > ulimit-h))
-            wh = (numpy.nonzero(mask))[0]
+            wh = (np.nonzero(mask))[0]
 
-            if len(wh) > 0: numpy.put(h, wh, -numpy.take(h, wh))
+            if len(wh) > 0: np.put(h, wh, -np.take(h, wh))
         ## Loop through parameters, computing the derivative for each
         for j in range(n):
             xp = xall.copy()
@@ -1729,17 +1729,17 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         if (self.debug): print('Entering qrfac...')
         machep = self.machar.machep
-        sz = numpy.shape(a)
+        sz = np.shape(a)
         m = sz[0]
         n = sz[1]
 
         ## Compute the initial column norms and initialize arrays
-        acnorm = numpy.zeros(n, numpy.float)
+        acnorm = np.zeros(n, float)
         for j in range(n):
             acnorm[j] = self.enorm(a[:,j])
         rdiag = acnorm.copy()
         wa = rdiag.copy()
-        ipvt = numpy.arange(n)
+        ipvt = np.arange(n)
 
         ## Reduce a to r with householder transformations
         minmn = min([m,n])
@@ -1747,7 +1747,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             if (pivot != 0):
                 ## Bring the column of largest norm into the pivot position
                 rmax = max(rdiag[j:])
-                kmax = (numpy.nonzero(rdiag[j:] == rmax) )[0]
+                kmax = (np.nonzero(rdiag[j:] == rmax) )[0]
                 ct = len(kmax)
                 kmax = kmax + j
                 if ct > 0:
@@ -1788,10 +1788,10 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                     ## *** Note optimization a(j:*,lk)
                     ## (corrected 20 Jul 2000)
                     if a[j,lj] != 0:
-                        a[j:,lk] = ajk - ajj * numpy.sum(ajk*ajj)/a[j,lj]
+                        a[j:,lk] = ajk - ajj * np.sum(ajk*ajj)/a[j,lj]
                         if ((pivot != 0) and (rdiag[k] != 0)):
                             temp = a[j,lk]/rdiag[k]
-                            rdiag[k] = rdiag[k] * numpy.sqrt(max((1.-temp**2), 0.))
+                            rdiag[k] = rdiag[k] * np.sqrt(max((1.-temp**2), 0.))
                             temp = rdiag[k]/wa[k]
                             if ((0.05*temp*temp) <= machep):
                                 rdiag[k] = self.enorm(a[j+1:,lk])
@@ -1880,7 +1880,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
     def qrsolv(self, r, ipvt, diag, qtb, sdiag):
         if (self.debug): print('Entering qrsolv...')
-        sz = numpy.shape(r)
+        sz = np.shape(r)
         m = sz[0]
         n = sz[1]
 
@@ -1889,7 +1889,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         for j in range(n):
             r[j:n,j] = r[j,j:n]
-        x = numpy.diagonal(r).copy()
+        x = np.diagonal(r).copy()
         wa = qtb.copy()
 
         ## Eliminate the diagonal matrix d using a givens rotation
@@ -1908,11 +1908,11 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                 if (sdiag[k] == 0): break
                 if (abs(r[k,k]) < abs(sdiag[k])):
                     cotan  = r[k,k]/sdiag[k]
-                    sine   = 0.5/numpy.sqrt(.25 + .25*cotan*cotan)
+                    sine   = 0.5/np.sqrt(.25 + .25*cotan*cotan)
                     cosine = sine*cotan
                 else:
                     tang   = sdiag[k]/r[k,k]
-                    cosine = 0.5/numpy.sqrt(.25 + .25*tang*tang)
+                    cosine = 0.5/np.sqrt(.25 + .25*tang*tang)
                     sine   = cosine*tang
 
                 ## Compute the modified diagonal element of r and the
@@ -1933,7 +1933,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         ## Solve the triangular system for z.  If the system is singular
         ## then obtain a least squares solution
         nsing = n
-        wh = (numpy.nonzero(sdiag == 0) )[0]
+        wh = (np.nonzero(sdiag == 0) )[0]
         if (len(wh) > 0):
             nsing = wh[0]
             wa[nsing:] = 0
@@ -1942,11 +1942,11 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             wa[nsing-1] = wa[nsing-1]/sdiag[nsing-1] ## Degenerate case
             ## *** Reverse loop ***
             for j in range(nsing-2,-1,-1):
-                sum = numpy.sum(r[j+1:nsing,j]*wa[j+1:nsing])
+                sum = np.sum(r[j+1:nsing,j]*wa[j+1:nsing])
                 wa[j] = (wa[j]-sum)/sdiag[j]
 
         ## Permute the components of z back to components of x
-        numpy.put(x, ipvt, wa)
+        np.put(x, ipvt, wa)
         return(r, x, sdiag)
 
 
@@ -2050,7 +2050,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         if (self.debug): print('Entering lmpar...')
         dwarf = self.machar.minnum
-        sz = numpy.shape(r)
+        sz = np.shape(r)
         m = sz[0]
         n = sz[1]
 
@@ -2058,7 +2058,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
         ## jacobian is rank-deficient, obtain a least-squares solution
         nsing = n
         wa1 = qtb.copy()
-        wh = (numpy.nonzero(numpy.diagonal(r) == 0) )[0]
+        wh = (np.nonzero(np.diagonal(r) == 0) )[0]
         if len(wh) > 0:
             nsing = wh[0]
             wa1[wh[0]:] = 0
@@ -2070,7 +2070,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                     wa1[0:j] = wa1[0:j] - r[0:j,j]*wa1[j]
 
         ## Note: ipvt here is a permutation array
-        numpy.put(x, ipvt, wa1)
+        np.put(x, ipvt, wa1)
 
         ## Initialize the iteration counter.  Evaluate the function at the
         ## origin, and test for acceptance of the gauss-newton direction
@@ -2087,10 +2087,10 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         parl = 0.
         if nsing >= n:
-            wa1 = numpy.take(diag, ipvt)*numpy.take(wa2, ipvt)/dxnorm
+            wa1 = np.take(diag, ipvt)*np.take(wa2, ipvt)/dxnorm
             wa1[0] = wa1[0] / r[0,0] ## Degenerate case
             for j in range(1,n):   ## Note "1" here, not zero
-                sum = numpy.sum(r[0:j,j]*wa1[0:j])
+                sum = np.sum(r[0:j,j]*wa1[0:j])
                 wa1[j] = (wa1[j] - sum)/r[j,j]
 
             temp = self.enorm(wa1)
@@ -2098,7 +2098,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         ## Calculate an upper bound, paru, for the zero of the function
         for j in range(n):
-            sum = numpy.sum(r[0:j+1,j]*qtb[0:j+1])
+            sum = np.sum(r[0:j+1,j]*qtb[0:j+1])
             wa1[j] = sum/diag[ipvt[j]]
         gnorm = self.enorm(wa1)
         paru = gnorm/delta
@@ -2117,7 +2117,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
             ## Evaluate the function at the current value of par
             if par == 0: par = max([dwarf, paru*0.001])
-            temp = numpy.sqrt(par)
+            temp = np.sqrt(par)
             wa1 = temp * diag
             [r, x, sdiag] = self.qrsolv(r, ipvt, wa1, qtb, sdiag)
             wa2 = diag*x
@@ -2130,7 +2130,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
                     (iter == 10)): break;
 
             ## Compute the newton correction
-            wa1 = numpy.take(diag, ipvt)*numpy.take(wa2, ipvt)/dxnorm
+            wa1 = np.take(diag, ipvt)*np.take(wa2, ipvt)/dxnorm
 
             for j in range(n-1):
                 wa1[j] = wa1[j]/sdiag[j]
@@ -2247,14 +2247,14 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             print('ERROR: r must be a two-dimensional matrix')
             return(-1)
 
-        s = numpy.shape(rr)
+        s = np.shape(rr)
         n = s[0]
         if s[0] != s[1]:
             print('ERROR: r must be a square matrix')
             return(-1)
 
         if ipvt is None:
-            ipvt = numpy.arange(n)
+            ipvt = np.arange(n)
         r = rr.copy()
         r.shape = [n,n]
 
@@ -2282,7 +2282,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
         ## For the full lower triangle of the covariance matrix
         ## in the strict lower triangle or and in wa
-        wa = numpy.repeat([r[0,0]], n)
+        wa = np.repeat([r[0,0]], n)
         for j in range(n):
             jj = ipvt[j]
             sing = j > l
@@ -2313,7 +2313,7 @@ class machar:
             self.minnum = 2.2250739e-308
             self.maxgam = 171.624376956302725
 
-        self.maxlog = numpy.log(self.maxnum)
-        self.minlog = numpy.log(self.minnum)
-        self.rdwarf = numpy.sqrt(self.minnum*1.5) * 10
-        self.rgiant = numpy.sqrt(self.maxnum) * 0.1
+        self.maxlog = np.log(self.maxnum)
+        self.minlog = np.log(self.minnum)
+        self.rdwarf = np.sqrt(self.minnum*1.5) * 10
+        self.rgiant = np.sqrt(self.maxnum) * 0.1

--- a/lib/stsci/tools/tests/test_bitmask.py
+++ b/lib/stsci/tools/tests/test_bitmask.py
@@ -10,7 +10,7 @@ import pytest
 
 from stsci.tools import bitmask
 
-MAX_INT_TYPE = np.maximum_sctype(np.int)
+MAX_INT_TYPE = np.maximum_sctype(int)
 MAX_UINT_TYPE = np.maximum_sctype(np.uint)
 MAX_UINT_FLAG = np.left_shift(
     MAX_UINT_TYPE(1),


### PR DESCRIPTION
This replaces the deprecated Numpy globals

```python
np.float
np.int
```

with the Python types

```python
float
int
```
 
to avoid (reduce) deprecation warnings.
