### PR TITLE
Fix unpickling of IrafPar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ of the list).
 4.0.1 (Unreleased)
 ------------------
 
+- Fixed unpickling of IrafPar. [#141]
 
 4.0.0 (2021-08-12)
 ------------------

--- a/lib/stsci/tools/basicpar.py
+++ b/lib/stsci/tools/basicpar.py
@@ -586,7 +586,8 @@ class IrafPar:
 
     def __setstate__(self, state):
         """Restore state info from pickle"""
-        self.__dict__ = state
+        self.__dict__.clear()
+        self.__dict__.update(state)
         if self.choice is not None:
             self._setChoiceDict()
 


### PR DESCRIPTION
### Description

Replacing `__dict__` in `__setstate__()` implicitly called `__setattr__`, which however hides the `__dict__` atribute from being set. To work around this, the method now instead updates the existing `__dict__` with the new values.

A trivial example (which replaces the `__dict__` with itself):
```python
from stsci.tools.basicpar import IrafParI

foo = IrafParI(['foo', 'i', 'h'])  # Create a simple integer IRAF variable
new_state = foo.__dict__.copy()    # Example dict that would be read in unpickle()
foo.__setstate__(new_state)        # This is called during unpickle()
```
Without this patch, this would give an exception:
```
  File "…/stsci/tools/basicpar.py", line 589, in __setstate__
    self.__dict__ = state
  File "…/stsci/tools/basicpar.py", line 559, in __setattr__
    raise AttributeError("No attribute %s for parameter %s" % (attr, self.name))
AttributeError: No attribute __dict__ for parameter foo
```
When this is called via unpickle. however, during the creation of the `AttributeError` the attribute `self.name` is accessed, which does not exist at the moment, which leads to a recursive creation of exceptions and finally to a stack overflow, specifically:
```python
import pickle
from stsci.tools.basicpar import IrafParI

foo = IrafParI(['foo', 'i', 'h'])  # Create a simple integer IRAF variable
ser_foo = pickle.dumps(foo)
foo2 = pickle.loads(ser_foo)
```

If this PR is applied, the clcache in PyRAF seems to work. It would be great to apply this (and to release a new version), since PyRAF still depends on stsci.tools.
