### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -107,11 +107,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip wheel setuptools
-        python -m pip install numpy==1.19.3 astropy==5.0.4
+        python -m pip install numpy==1.21.6 astropy==5.0.4
         python -m pip install -e .[test]
     - name: Test with old deps
       run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "stsci.tools"
 description = "Collection of STScI utility functions"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "STScI" },
 ]
@@ -41,7 +41,7 @@ convertlog = "stsci.tools.convertlog:main"
 
 [project.optional-dependencies]
 test = [
-    "pytest",
+    "pytest>=9.0",
     "pytest-astropy-header",
     "pytest-doctestplus",
 ]
@@ -76,12 +76,12 @@ where = [
 [tool.setuptools_scm]
 version_file = "lib/stsci/tools/version.py"
 
-[tool.pytest.ini_options]
-minversion = "6"
+[tool.pytest]
+minversion = "9.0"
 testpaths = [
     "lib/stsci/tools",
 ]
-addopts = "--doctest-modules"
+addopts = ["--doctest-modules"]
 astropy_header = true
 xfail_strict = true
 filterwarnings = [


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsci.tools/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`

<!-- In addition please ensure that the pull request title is descriptive. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
